### PR TITLE
feat(ayah-of-the-day): phase 1 — content + automation

### DIFF
--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -1,0 +1,87 @@
+name: Rotate Ayah of the Day Seed
+
+on:
+  schedule:
+    # 00:00 UTC on the 1st of every month
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+    inputs:
+      regenerate:
+        description: "Force-regenerate the current month's seed even if one already exists"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rotate-ayah-seed
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository == 'mazipan/baca-quran.id' || github.repository == 'mazipan-quran-offline/baca-quran.id'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          token: ${{ secrets.PERSONAL_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Rotate seed
+        id: rotate
+        env:
+          REGENERATE: ${{ inputs.regenerate || 'false' }}
+        run: |
+          node <<'EOF'
+          const fs = require('node:fs');
+          const path = 'src/data/ayah-of-the-day-seeds.json';
+          const raw = fs.readFileSync(path, 'utf8');
+          const data = JSON.parse(raw);
+
+          const now = new Date();
+          const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+          const year = now.getUTCFullYear();
+          const regenerate = process.env.REGENERATE === 'true';
+
+          const hadSeed = Object.prototype.hasOwnProperty.call(data.seeds, mm);
+          let action;
+          if (hadSeed && !regenerate) {
+            action = 'skipped';
+          } else {
+            // Random 32-bit positive integer.
+            const seed = Math.floor(Math.random() * 0x7fffffff);
+            data.seeds[mm] = seed;
+            action = hadSeed ? 'regenerated' : 'added';
+          }
+
+          data.lastRotation = {
+            month: mm,
+            year,
+            action,
+            generatedAt: now.toISOString()
+          };
+
+          fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
+
+          // Expose to subsequent steps.
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `action=${action}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `month=${mm}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `year=${year}\n`);
+          EOF
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/data/ayah-of-the-day-seeds.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(ayah-of-the-day): seed for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }} (${{ steps.rotate.outputs.action }})"
+          git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/switch-ayah-theme.yml
+++ b/.github/workflows/switch-ayah-theme.yml
@@ -1,0 +1,72 @@
+name: Switch Ayah of the Day Theme
+
+on:
+  workflow_dispatch:
+    inputs:
+      theme:
+        description: "Theme to force ('auto' clears the override and restores date-based resolution)"
+        required: true
+        type: choice
+        default: auto
+        options:
+          - auto
+          - ramadhan
+
+permissions:
+  contents: write
+
+concurrency:
+  group: switch-ayah-theme
+  cancel-in-progress: false
+
+jobs:
+  switch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.repository == 'mazipan/baca-quran.id' || github.repository == 'mazipan-quran-offline/baca-quran.id'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          token: ${{ secrets.PERSONAL_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Update theme override
+        env:
+          THEME_INPUT: ${{ inputs.theme }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          node <<'EOF'
+          const fs = require('node:fs');
+          const path = 'src/data/ayah-of-the-day-config.json';
+          const raw = fs.readFileSync(path, 'utf8');
+          const data = JSON.parse(raw);
+
+          const input = process.env.THEME_INPUT;
+          const value = input === 'auto' ? null : input;
+
+          data.forcedThemeId = value;
+          data.lastSwitch = {
+            value,
+            switchedAt: new Date().toISOString(),
+            actor: process.env.ACTOR || null
+          };
+
+          fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
+          EOF
+
+      - name: Commit and push
+        env:
+          THEME_INPUT: ${{ inputs.theme }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/data/ayah-of-the-day-config.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit (already on requested theme)."
+            exit 0
+          fi
+          git commit -m "chore(ayah-of-the-day): switch theme to ${THEME_INPUT} by ${ACTOR}"
+          git push origin HEAD:${{ github.ref_name }}

--- a/src/data/ayah-of-the-day-config.json
+++ b/src/data/ayah-of-the-day-config.json
@@ -1,0 +1,8 @@
+{
+	"forcedThemeId": null,
+	"lastSwitch": {
+		"value": null,
+		"switchedAt": null,
+		"actor": null
+	}
+}

--- a/src/data/ayah-of-the-day-seeds.json
+++ b/src/data/ayah-of-the-day-seeds.json
@@ -1,0 +1,11 @@
+{
+	"seeds": {
+		"05": 1846203715
+	},
+	"lastRotation": {
+		"month": "05",
+		"year": 2026,
+		"action": "added",
+		"generatedAt": "2026-05-07T00:00:00Z"
+	}
+}

--- a/src/data/ayah-of-the-day.ts
+++ b/src/data/ayah-of-the-day.ts
@@ -1,0 +1,100 @@
+import config from './ayah-of-the-day-config.json';
+
+export type AyahPick = {
+	s: number;
+	v: number;
+};
+
+export type Theme = {
+	id: string;
+	labelKey: string;
+	emoji: string;
+	hijriMonth: number;
+	hijriDayRange?: [number, number];
+	enabled?: boolean;
+	pool: AyahPick[];
+};
+
+export const defaultPool: AyahPick[] = [
+	{ s: 1, v: 1 },
+	{ s: 1, v: 2 },
+	{ s: 1, v: 5 },
+	{ s: 2, v: 152 },
+	{ s: 2, v: 153 },
+	{ s: 2, v: 155 },
+	{ s: 2, v: 156 },
+	{ s: 2, v: 186 },
+	{ s: 2, v: 216 },
+	{ s: 2, v: 255 },
+	{ s: 2, v: 286 },
+	{ s: 3, v: 8 },
+	{ s: 3, v: 26 },
+	{ s: 3, v: 134 },
+	{ s: 3, v: 139 },
+	{ s: 3, v: 159 },
+	{ s: 3, v: 173 },
+	{ s: 3, v: 200 },
+	{ s: 5, v: 32 },
+	{ s: 6, v: 162 },
+	{ s: 7, v: 199 },
+	{ s: 9, v: 51 },
+	{ s: 11, v: 6 },
+	{ s: 13, v: 11 },
+	{ s: 13, v: 28 },
+	{ s: 14, v: 7 },
+	{ s: 16, v: 97 },
+	{ s: 17, v: 24 },
+	{ s: 17, v: 80 },
+	{ s: 18, v: 10 },
+	{ s: 20, v: 114 },
+	{ s: 21, v: 87 },
+	{ s: 21, v: 107 },
+	{ s: 25, v: 74 },
+	{ s: 28, v: 24 },
+	{ s: 29, v: 69 },
+	{ s: 30, v: 21 },
+	{ s: 33, v: 35 },
+	{ s: 39, v: 53 },
+	{ s: 40, v: 60 },
+	{ s: 41, v: 30 },
+	{ s: 49, v: 13 },
+	{ s: 55, v: 13 },
+	{ s: 65, v: 3 },
+	{ s: 67, v: 2 },
+	{ s: 89, v: 27 },
+	{ s: 93, v: 5 },
+	{ s: 94, v: 5 },
+	{ s: 94, v: 6 },
+	{ s: 103, v: 3 }
+];
+
+export const themes: Theme[] = [
+	{
+		id: 'ramadhan',
+		labelKey: 'ayahOfTheDay.themes.ramadhan',
+		emoji: '🌙',
+		hijriMonth: 9,
+		pool: [
+			{ s: 2, v: 183 },
+			{ s: 2, v: 184 },
+			{ s: 2, v: 185 },
+			{ s: 2, v: 186 },
+			{ s: 2, v: 187 },
+			{ s: 17, v: 78 },
+			{ s: 25, v: 30 },
+			{ s: 73, v: 20 },
+			{ s: 96, v: 1 },
+			{ s: 96, v: 2 },
+			{ s: 96, v: 3 },
+			{ s: 96, v: 4 },
+			{ s: 96, v: 5 },
+			{ s: 97, v: 1 },
+			{ s: 97, v: 2 },
+			{ s: 97, v: 3 },
+			{ s: 97, v: 4 },
+			{ s: 97, v: 5 }
+		]
+	}
+];
+
+export const forcedThemeId: string | null = config.forcedThemeId;


### PR DESCRIPTION
Adds the data scaffolding for the upcoming "Ayah of the Day" feature
(#405) without any user-visible UI yet:

- `src/data/ayah-of-the-day.ts` — types, ~50-verse default pool, and a
  Ramadhan-themed pool keyed by Hijri month 9. Exposes `forcedThemeId`
  read from a JSON config so it can be flipped without touching code.
- `src/data/ayah-of-the-day-seeds.json` — per-month seeds (annual cycle).
  Seeded for the current month so the feature can work day-one.
- `src/data/ayah-of-the-day-config.json` — `forcedThemeId` override +
  audit metadata.
- `.github/workflows/rotate-ayah-seed.yml` — monthly cron that fills any
  missing month seed; idempotent once 12 months are filled.
- `.github/workflows/switch-ayah-theme.yml` — manual `workflow_dispatch`
  for switching the forced theme from the Actions tab.

Phase 2 (UI) will follow.

Refs #405