### PR TITLE
feat(ayah-of-the-day): phase 2 — UI on home page

### DIFF
--- a/src/lib/AyahOfTheDay.svelte
+++ b/src/lib/AyahOfTheDay.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import CardShadow from './CardShadow.svelte';
+	import { t } from './translations/store';
+	import { defaultPool, themes, forcedThemeId } from '$data/ayah-of-the-day';
+	import seedsData from '$data/ayah-of-the-day-seeds.json';
+	import { pickAyahForDate } from './utils/dailyPick';
+	import type { Theme, AyahPick } from '$data/ayah-of-the-day';
+	import ArrowRightIcon from './icons/ArrowRightIcon.svelte';
+
+	type Loaded = {
+		pick: AyahPick;
+		theme: Theme | null;
+		arabic: string;
+		translation: string;
+		surahLatin: string;
+	};
+
+	let loaded: Loaded | null = $state(null);
+
+	async function resolveToday() {
+		const seeds = (seedsData as { seeds: Record<string, number> }).seeds;
+		const { pick, theme } = pickAyahForDate(new Date(), seeds, themes, defaultPool, forcedThemeId);
+		const surahMod = await import(`../data/surah-data/${pick.s}.ts`);
+		const surahInfoMod = await import(`../data/surah-info/${pick.s}.ts`);
+		const surah = surahMod.default[String(pick.s)];
+		const surahInfo = surahInfoMod.default.current;
+		loaded = {
+			pick,
+			theme,
+			arabic: surah.text[String(pick.v)],
+			translation: surah.translations.id.text[String(pick.v)],
+			surahLatin: surahInfo.latin
+		};
+	}
+
+	onMount(() => {
+		resolveToday();
+	});
+</script>
+
+<div class="flex gap-2 mb-2 mt-2">
+	<h2 class="text-xl font-bold">
+		{$t('ayahOfTheDay.title')}
+	</h2>
+</div>
+
+{#if loaded === null}
+	<CardShadow>
+		<p class="text-foreground-secondary text-sm">{$t('ayahOfTheDay.loading')}</p>
+	</CardShadow>
+{:else}
+	<CardShadow>
+		<div class="flex flex-col gap-3">
+			<div class="flex justify-between items-center gap-2">
+				<span class="text-xs text-foreground-secondary">
+					{loaded.surahLatin} : {loaded.pick.v}
+				</span>
+				{#if loaded.theme}
+					<span class="text-xs px-2 py-0.5 rounded-full bg-primary">
+						{loaded.theme.emoji}
+						{$t(loaded.theme.labelKey)}
+					</span>
+				{/if}
+			</div>
+			<p class="font-arabic text-2xl text-right leading-loose" dir="rtl">
+				{loaded.arabic}
+			</p>
+			<p class="text-sm text-foreground-secondary">
+				{loaded.translation}
+			</p>
+			<a
+				href={`/surah/${loaded.pick.s}/#ayat-${loaded.pick.v}`}
+				class="flex bg-primary items-center justify-center gap-2 cursor-pointer p-2 rounded-md focus:ring-2 focus:ring-blue-500 text-sm"
+				data-sveltekit-reload
+			>
+				{$t('ayahOfTheDay.readMore')}
+				<ArrowRightIcon />
+			</a>
+		</div>
+	</CardShadow>
+{/if}

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -90,5 +90,13 @@
 		"findWhatLetter": "Find what letter?",
 		"shareVerseTitle": "🧵 Share Surah {{surahLatin}}, Verse {{verseNumber}}",
 		"tafsirTitle": "💠 Translation & Tafsir Surah {{surahLatin}}, Verse {{verseNumber}}"
+	},
+	"ayahOfTheDay": {
+		"title": "🌅 Ayah of the Day",
+		"readMore": "Read full ayah",
+		"loading": "Loading today's ayah…",
+		"themes": {
+			"ramadhan": "Ramadhan"
+		}
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -90,5 +90,13 @@
 		"findWhatLetter": "Cari surat apa?",
 		"shareVerseTitle": "🧵 Bagikan Surat {{surahLatin}}, Ayat {{verseNumber}}",
 		"tafsirTitle": "💠 Terjemah & Tafsir Surat {{surahLatin}}, Ayat {{verseNumber}}"
+	},
+	"ayahOfTheDay": {
+		"title": "🌅 Ayat Hari Ini",
+		"readMore": "Baca selengkapnya",
+		"loading": "Memuat ayat hari ini…",
+		"themes": {
+			"ramadhan": "Bulan Ramadhan"
+		}
 	}
 }

--- a/src/lib/utils/dailyPick.ts
+++ b/src/lib/utils/dailyPick.ts
@@ -1,0 +1,59 @@
+import type { AyahPick, Theme } from '$data/ayah-of-the-day';
+import { getHijriMonthDay } from './hijri';
+
+const FALLBACK_SEED = 1846203715;
+
+export function hashString(s: string): number {
+	let h = 0;
+	for (let i = 0; i < s.length; i++) {
+		h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+	}
+	return Math.abs(h);
+}
+
+export function getActiveTheme(
+	date: Date,
+	themes: Theme[],
+	forcedThemeId: string | null
+): Theme | null {
+	if (forcedThemeId) {
+		const forced = themes.find((t) => t.id === forcedThemeId);
+		if (forced && forced.enabled !== false) return forced;
+	}
+	const { month, day } = getHijriMonthDay(date);
+	for (const t of themes) {
+		if (t.enabled === false) continue;
+		if (t.hijriMonth !== month) continue;
+		if (t.hijriDayRange) {
+			const [from, to] = t.hijriDayRange;
+			if (day < from || day > to) continue;
+		}
+		return t;
+	}
+	return null;
+}
+
+function toLocalYYYYMMDD(d: Date): string {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}${m}${day}`;
+}
+
+function getMonthKey(d: Date): string {
+	return String(d.getMonth() + 1).padStart(2, '0');
+}
+
+export function pickAyahForDate(
+	date: Date,
+	seeds: Record<string, number>,
+	themes: Theme[],
+	defaultPool: AyahPick[],
+	forcedThemeId: string | null
+): { pick: AyahPick; theme: Theme | null } {
+	const theme = getActiveTheme(date, themes, forcedThemeId);
+	const pool = theme?.pool ?? defaultPool;
+	const seed = seeds[getMonthKey(date)] ?? FALLBACK_SEED;
+	const index = hashString(toLocalYYYYMMDD(date) + String(seed)) % pool.length;
+	return { pick: pool[index], theme };
+}

--- a/src/lib/utils/hijri.ts
+++ b/src/lib/utils/hijri.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns the Hijri (Umm al-Qura) month and day for a given Gregorian date.
+ * Uses the engine's built-in Islamic calendar — no third-party deps.
+ */
+export function getHijriMonthDay(d: Date): { month: number; day: number } {
+	const fmt = new Intl.DateTimeFormat('en-u-ca-islamic-umalqura', {
+		month: 'numeric',
+		day: 'numeric'
+	});
+	const parts = fmt.formatToParts(d);
+	const month = Number(parts.find((p) => p.type === 'month')?.value);
+	const day = Number(parts.find((p) => p.type === 'day')?.value);
+	return { month, day };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import AyahOfTheDay from '$lib/AyahOfTheDay.svelte';
 	import CardShadow from '$lib/CardShadow.svelte';
 	import LastReadVerses from '$lib/LastReadVerses.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
@@ -63,6 +64,7 @@
 <div class="px-4 flex flex-col gap-2">
 	<PinnedSurah />
 	<LastReadVerses />
+	<AyahOfTheDay />
 
 	<div class="flex gap-2 mt-2 mb-2">
 		<h2 class="text-xl font-bold">


### PR DESCRIPTION
Phase 2 of #405 — adds the user-visible "Ayah of the Day" card on the home page on top of the data + automation that landed in #406.

## What changed

- `src/lib/utils/hijri.ts` — Hijri month/day via the engine's built-in Umm al-Qura calendar (`Intl.DateTimeFormat('en-u-ca-islamic-umalqura')`). No third-party deps.
- `src/lib/utils/dailyPick.ts` — pure picker:
  - `getActiveTheme()` resolves `forcedThemeId` → first enabled theme matching today's Hijri month/day → `null`.
  - `pickAyahForDate()` indexes the active pool with `hash(YYYYMMDD + monthSeed)`.
- `src/lib/AyahOfTheDay.svelte` — card with a theme badge when active, Arabic + Indonesian translation, and a deep-link to the full ayah. SSR shows a small loading skeleton; hydration runs the date-based pick client-side so the static prerender stays valid.
- `src/routes/+page.svelte` — mounts `<AyahOfTheDay />` between `<LastReadVerses />` and the "🌟 Fitur" heading.
- `src/lib/translations/{id,en}.json` — adds `ayahOfTheDay.title`, `readMore`, `loading`, and `themes.ramadhan`.

## How it picks
1. Read today's Gregorian month → look up `seeds[MM]` from `ayah-of-the-day-seeds.json` (fallback constant if missing).
2. Read `forcedThemeId` from `ayah-of-the-day-config.json`. If set, force that theme. Else check Hijri month against `themes[]`.
3. Pool = themed pool (if active) or default pool (~50 verses).
4. Index = `abs(hash(YYYYMMDD + seed)) % pool.length`.

## Test plan
- [ ] After merge + deploy, the home page shows an Ayah of the Day card between Last Read and Features.
- [ ] The card shows surah name + verse, Arabic, Indonesian translation, and a "Baca selengkapnya" link to `/surah/{s}/#ayat-{v}`.
- [ ] Run **Switch Ayah of the Day Theme** workflow with `theme=ramadhan` → after deploy, the card shows the 🌙 Ramadhan badge and a verse from the Ramadhan pool.
- [ ] Run the same workflow with `theme=auto` → after deploy, the card returns to date-based selection (no badge outside Hijri month 9).
- [ ] Reload the home page on the same day → same verse. Reload tomorrow (or change device clock) → different verse.
- [ ] EN/ID toggle re-renders the card title and CTA labels (verse translation stays Indonesian — same as the rest of the app).
- [ ] Verify on a real device that the static prerender + hydration produces no layout shift.

## Verified locally
- `pnpm run check` → 0 errors (only pre-existing warnings in unrelated files).
- `pnpm run lint` → 0 errors.
- `pnpm run build:ci` → green; home page prerenders.

Closes #405.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWW3ctN8cd6VAkM3QnyBqm)_