### PR TITLE
feat(hijri): show Hijri date and Islamic events in header

### DIFF
--- a/src/data/islamic-events.ts
+++ b/src/data/islamic-events.ts
@@ -1,0 +1,129 @@
+export interface IslamicEvent {
+	id: string;
+	hijriMonth: number;
+	hijriDay: number;
+	nameId: string;
+	nameEn: string;
+	type: 'holiday' | 'fasting' | 'observance';
+}
+
+export const ISLAMIC_EVENTS: readonly IslamicEvent[] = [
+	{
+		id: 'tahun-baru-hijriyah',
+		hijriMonth: 1,
+		hijriDay: 1,
+		nameId: 'Tahun Baru Hijriyah',
+		nameEn: 'Islamic New Year',
+		type: 'holiday'
+	},
+	{
+		id: 'asyura',
+		hijriMonth: 1,
+		hijriDay: 10,
+		nameId: 'Hari Asyura',
+		nameEn: 'Day of Ashura',
+		type: 'fasting'
+	},
+	{
+		id: 'maulid-nabi',
+		hijriMonth: 3,
+		hijriDay: 12,
+		nameId: 'Maulid Nabi Muhammad',
+		nameEn: 'Mawlid an-Nabi',
+		type: 'observance'
+	},
+	{
+		id: 'isra-miraj',
+		hijriMonth: 7,
+		hijriDay: 27,
+		nameId: "Isra' Mi'raj",
+		nameEn: "Isra' and Mi'raj",
+		type: 'observance'
+	},
+	{
+		id: 'nisfu-syaban',
+		hijriMonth: 8,
+		hijriDay: 15,
+		nameId: "Nisfu Sya'ban",
+		nameEn: "Mid-Sha'ban",
+		type: 'observance'
+	},
+	{
+		id: 'awal-ramadan',
+		hijriMonth: 9,
+		hijriDay: 1,
+		nameId: 'Awal Ramadan',
+		nameEn: 'Start of Ramadan',
+		type: 'fasting'
+	},
+	{
+		id: 'nuzulul-quran',
+		hijriMonth: 9,
+		hijriDay: 17,
+		nameId: "Nuzulul Qur'an",
+		nameEn: "Nuzul al-Qur'an",
+		type: 'observance'
+	},
+	{
+		id: 'idul-fitri',
+		hijriMonth: 10,
+		hijriDay: 1,
+		nameId: 'Idul Fitri',
+		nameEn: 'Eid al-Fitr',
+		type: 'holiday'
+	},
+	{
+		id: 'tarwiyah',
+		hijriMonth: 12,
+		hijriDay: 8,
+		nameId: 'Hari Tarwiyah',
+		nameEn: 'Day of Tarwiyah',
+		type: 'fasting'
+	},
+	{
+		id: 'arafah',
+		hijriMonth: 12,
+		hijriDay: 9,
+		nameId: 'Hari Arafah',
+		nameEn: 'Day of Arafah',
+		type: 'fasting'
+	},
+	{
+		id: 'idul-adha',
+		hijriMonth: 12,
+		hijriDay: 10,
+		nameId: 'Idul Adha',
+		nameEn: 'Eid al-Adha',
+		type: 'holiday'
+	},
+	{
+		id: 'tasyrik-1',
+		hijriMonth: 12,
+		hijriDay: 11,
+		nameId: 'Hari Tasyrik',
+		nameEn: 'Days of Tashriq',
+		type: 'observance'
+	},
+	{
+		id: 'tasyrik-2',
+		hijriMonth: 12,
+		hijriDay: 12,
+		nameId: 'Hari Tasyrik',
+		nameEn: 'Days of Tashriq',
+		type: 'observance'
+	},
+	{
+		id: 'tasyrik-3',
+		hijriMonth: 12,
+		hijriDay: 13,
+		nameId: 'Hari Tasyrik',
+		nameEn: 'Days of Tashriq',
+		type: 'observance'
+	}
+];
+
+// Note: lookup is by Umm al-Qura calendar — official Indonesian holiday dates
+// (Kemenag rukyat) may shift ±1 day, especially for Idul Fitri / Idul Adha.
+export function getEventsForHijriDate(month: number, day: number): IslamicEvent[] {
+	return ISLAMIC_EVENTS.filter((e) => e.hijriMonth === month && e.hijriDay === day);
+}

--- a/src/lib/Clock.svelte
+++ b/src/lib/Clock.svelte
@@ -1,7 +1,10 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte';
+	import { languageStore } from './checkLanguaguage';
+	import { formatHijriDate } from './utils/hijri';
 
 	let time = $state(new Date());
+	let hijriLabel = $derived(formatHijriDate(time, $languageStore));
 
 	// these automatically update when `time`
 	// changes, because of the `$:` prefix
@@ -56,6 +59,9 @@
 		</div>
 		<div class="flex justify-end text-lg">
 			{new Date().toLocaleDateString('id-ID', { month: 'short', day: '2-digit', year: 'numeric' })}
+		</div>
+		<div class="flex justify-end text-sm opacity-75">
+			{hijriLabel}
 		</div>
 	</div>
 </div>

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import LanguageChanger from './LanguageChanger.svelte';
 	import ThemeSwicther from './ThemeSwicther.svelte';
+	import HijriDate from './HijriDate.svelte';
 	import ResetIcon from './icons/ResetIcon.svelte';
 
 	interface Props {
@@ -35,6 +36,8 @@
 	<a href="/" data-sveltekit-reload>
 		<h1 class="font-bold text-2xl">Baca-Quran.id</h1>
 	</a>
+
+	<HijriDate />
 
 	<div class="flex gap-2">
 		<a class="cursor-pointer p-2 rounded-md hover:bg-secondary focus:bg-secondary" href="/sync">

--- a/src/lib/HijriDate.svelte
+++ b/src/lib/HijriDate.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { languageStore } from './checkLanguaguage';
+	import { getHijriDate, HIJRI_MONTHS_ID, HIJRI_MONTHS_EN } from './utils/hijri';
+	import { getEventsForHijriDate, type IslamicEvent } from '$data/islamic-events';
+	import { t } from './translations/store';
+
+	let now = $state<Date | null>(null);
+
+	let hijri = $derived(now ? getHijriDate(now) : null);
+	let events = $derived<IslamicEvent[]>(hijri ? getEventsForHijriDate(hijri.month, hijri.day) : []);
+
+	let label = $derived.by(() => {
+		if (!hijri) return '';
+		const lang = $languageStore;
+		const months = lang === 'en' ? HIJRI_MONTHS_EN : HIJRI_MONTHS_ID;
+		const suffix = lang === 'en' ? 'AH' : 'H';
+		return `${hijri.day} ${months[hijri.month - 1]} ${hijri.year} ${suffix}`;
+	});
+
+	let tooltip = $derived.by(() => {
+		if (events.length === 0) return label;
+		const lang = $languageStore;
+		const names = events.map((e) => (lang === 'en' ? e.nameEn : e.nameId)).join(', ');
+		return `${$t('hijri.todayEvent')}: ${names}`;
+	});
+
+	onMount(() => {
+		now = new Date();
+		const next = new Date();
+		next.setHours(24, 0, 5, 0);
+		const ms = next.getTime() - Date.now();
+		const timer = setTimeout(() => {
+			now = new Date();
+		}, ms);
+		return () => clearTimeout(timer);
+	});
+</script>
+
+{#if hijri}
+	<div
+		class="hidden sm:flex items-center gap-1.5 text-sm select-none"
+		title={tooltip}
+		aria-label={tooltip}
+	>
+		<span>{label}</span>
+		{#if events.length > 0}
+			<span
+				class="inline-block w-2 h-2 rounded-full bg-blue-500"
+				class:bg-red-500={events[0].type === 'holiday'}
+				class:bg-green-500={events[0].type === 'fasting'}
+				aria-hidden="true"
+			></span>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -98,5 +98,9 @@
 		"themes": {
 			"ramadhan": "Ramadhan"
 		}
+	},
+	"hijri": {
+		"suffix": "AH",
+		"todayEvent": "Today"
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -98,5 +98,9 @@
 		"themes": {
 			"ramadhan": "Bulan Ramadhan"
 		}
+	},
+	"hijri": {
+		"suffix": "H",
+		"todayEvent": "Hari ini"
 	}
 }

--- a/src/lib/utils/hijri.ts
+++ b/src/lib/utils/hijri.ts
@@ -1,14 +1,89 @@
 /**
+ * Hijri (Umm al-Qura) date helpers — pure JS, no external deps.
+ *
+ * Note: Umm al-Qura may differ by ±1 day from Indonesian government
+ * rukyat-based dates, especially around Idul Fitri and Idul Adha.
+ */
+
+export const HIJRI_MONTHS_ID = [
+	'Muharram',
+	'Safar',
+	"Rabi'ul Awal",
+	"Rabi'ul Akhir",
+	'Jumadil Awal',
+	'Jumadil Akhir',
+	'Rajab',
+	"Sya'ban",
+	'Ramadan',
+	'Syawal',
+	"Dzulqa'dah",
+	'Dzulhijjah'
+] as const;
+
+export const HIJRI_MONTHS_EN = [
+	'Muharram',
+	'Safar',
+	"Rabi' al-Awwal",
+	"Rabi' al-Thani",
+	'Jumada al-Awwal',
+	'Jumada al-Thani',
+	'Rajab',
+	"Sha'ban",
+	'Ramadan',
+	'Shawwal',
+	"Dhu al-Qi'dah",
+	'Dhu al-Hijjah'
+] as const;
+
+export const HIJRI_MONTHS_AR = [
+	'محرم',
+	'صفر',
+	'ربيع الأول',
+	'ربيع الثاني',
+	'جمادى الأولى',
+	'جمادى الآخرة',
+	'رجب',
+	'شعبان',
+	'رمضان',
+	'شوال',
+	'ذو القعدة',
+	'ذو الحجة'
+] as const;
+
+/**
  * Returns the Hijri (Umm al-Qura) month and day for a given Gregorian date.
- * Uses the engine's built-in Islamic calendar — no third-party deps.
+ * Kept for backwards compatibility with existing callers (dailyPick, etc.).
  */
 export function getHijriMonthDay(d: Date): { month: number; day: number } {
+	const { month, day } = getHijriDate(d);
+	return { month, day };
+}
+
+/**
+ * Returns the full Hijri (Umm al-Qura) year/month/day for a given Gregorian date.
+ */
+export function getHijriDate(d: Date): { year: number; month: number; day: number } {
 	const fmt = new Intl.DateTimeFormat('en-u-ca-islamic-umalqura', {
+		year: 'numeric',
 		month: 'numeric',
 		day: 'numeric'
 	});
 	const parts = fmt.formatToParts(d);
-	const month = Number(parts.find((p) => p.type === 'month')?.value);
-	const day = Number(parts.find((p) => p.type === 'day')?.value);
-	return { month, day };
+	const yearRaw = parts.find((p) => p.type === 'year')?.value ?? '0';
+	const monthRaw = parts.find((p) => p.type === 'month')?.value ?? '0';
+	const dayRaw = parts.find((p) => p.type === 'day')?.value ?? '0';
+	const year = Number(yearRaw.replace(/\D/g, ''));
+	const month = Number(monthRaw);
+	const day = Number(dayRaw);
+	return { year, month, day };
+}
+
+/**
+ * Format a Gregorian Date as a localized Hijri string, e.g. "15 Ramadan 1447 H".
+ */
+export function formatHijriDate(d: Date, locale: 'id' | 'en'): string {
+	const { year, month, day } = getHijriDate(d);
+	const months = locale === 'en' ? HIJRI_MONTHS_EN : HIJRI_MONTHS_ID;
+	const suffix = locale === 'en' ? 'AH' : 'H';
+	return `${day} ${months[month - 1]} ${year} ${suffix}`;
 }


### PR DESCRIPTION
Phase 1 of #404 (item #12). Adds today's Hijri date as a label in the
global Header, with an indicator dot when an Islamic event (e.g. 1
Ramadan, 10 Muharram, Idul Fitri) falls on that date. Pure-JS via
Intl.DateTimeFormat('en-u-ca-islamic-umalqura') — no new deps, no API.

- Extend src/lib/utils/hijri.ts with getHijriDate, month-name constants
  (id/en/ar), and formatHijriDate. The existing getHijriMonthDay export
  is preserved so dailyPick.ts is unaffected.
- New src/data/islamic-events.ts with fixed-date events and lookup.
- New src/lib/HijriDate.svelte mounted in Header.svelte; recomputes once
  per local midnight rather than every second.
- Bonus: Clock.svelte (used on /jadwal-sholat) now shows a Hijri line
  under the Gregorian date.
- Translations: hijri.suffix and hijri.todayEvent in id/en.

Refs #408