### PR TITLE
feat(hijri): add /kalender-hijriyah calendar page

### DIFF
--- a/.claude/skills/add-feature-page/SKILL.md
+++ b/.claude/skills/add-feature-page/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: add-feature-page
+description: Add a new feature page/route to this SvelteKit + Svelte 5 app following baca-quran.id conventions. Use whenever the user asks to add a new page, new route, new feature with its own URL (e.g. "/kalender-hijriyah", "/khatam-tracker"), or expose a feature through the navigation drawer. Covers route creation, prerender registration, sitemap, SEO, breadcrumb, drawer, i18n, and verification.
+---
+
+# Add a feature page
+
+This repo is a statically-prerendered SvelteKit app (adapter-static).
+Adding a new page touches more than just `+page.svelte` — miss any of
+these and the page will silently be missing from prerender, sitemap, or
+nav. Follow every step.
+
+## 1. Create the route
+
+```text
+src/routes/<slug>/+page.svelte
+```
+
+- Slug is lowercase, hyphenated, Indonesian where the rest of the
+  routes already are (e.g. `jadwal-sholat`, `pencatat-ibadah`,
+  `kalender-hijriyah`).
+- **Do not** add a `+page.ts`. `src/routes/+layout.ts` already sets
+  `prerender = true` and `trailingSlash = 'always'` globally.
+
+Skeleton:
+
+```svelte
+<script lang="ts">
+	import Breadcrumb from '$lib/Breadcrumb.svelte';
+	import MetaTag from '$lib/MetaTag.svelte';
+	import { TITLE_CONSTANTS } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import { t } from '$lib/translations/store';
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	const META_TITLE = `<Indonesian title> | ${TITLE_CONSTANTS.TITLE_META}`;
+	const META_DESC = '<Indonesian description, mention free, no ads, no analytics>';
+</script>
+
+<svelte:head>
+	<MetaTag title={META_TITLE} desc={META_DESC} url={`${TITLE_CONSTANTS.PATH}<slug>/`} />
+</svelte:head>
+
+<div class="flex gap-2 px-4 mb-4">
+	<h1 class="text-3xl font-bold">
+		🌙 {isEnglish ? 'English title' : 'Judul Indonesia'}
+	</h1>
+</div>
+
+<div class="px-4 mb-4">
+	<Breadcrumb
+		items={[
+			{ text: isEnglish ? '🏠 Home' : '🏠 Beranda', href: '/' },
+			{ text: isEnglish ? '<English>' : '<Indonesian>', href: '/<slug>/' }
+		]}
+	/>
+</div>
+
+<div class="px-4 flex flex-col gap-6">
+	<!-- feature content -->
+</div>
+```
+
+Use Svelte 5 runes (`$state`, `$derived`, `$props`, `$effect`). **Never**
+use `export let` or `$:`.
+
+## 2. Register the URL in `scripts/routes.js`
+
+This single array drives **both** the build's `prerender.entries`
+(via `svelte.config.js`) **and** the sitemap (`scripts/makeSitemap.js`).
+Skipping this is the single most common mistake when adding a page.
+
+Open `scripts/routes.js` and insert the new path into `staticUrls`,
+keeping the existing alphabetical-ish grouping:
+
+```js
+export const staticUrls = [
+	// ...existing entries
+	'/<slug>'
+	// ...
+];
+```
+
+No leading `/` is fine — match the existing style (no trailing slash in
+this list; the sitemap and prerender machinery add it).
+
+## 3. Add SEO constants (optional but preferred)
+
+For consistency with other pages, add to `src/lib/constants.ts`:
+
+```ts
+export const META_TITLE_<UPPER_SLUG> = `<Title> | ${TITLE_CONSTANTS.TITLE_META}`;
+export const META_DESC_<UPPER_SLUG> = `<Description>`;
+```
+
+…then import and use them in `+page.svelte` instead of inline strings.
+
+## 4. Add a drawer menu entry (if user-facing)
+
+Edit `src/lib/DrawerMenus.svelte`:
+
+```svelte
+<li class="sidebar__item">
+	<a
+		data-sveltekit-reload
+		href="/<slug>/"
+		class="flex gap-2 items-center p-2 rounded-md hover:bg-primary focus:bg-primary"
+	>
+		<<Icon> />
+		{$t('navigation.<key>')}
+	</a>
+</li>
+```
+
+If no existing icon in `src/lib/icons/` fits, add one by copying
+`HashtagIcon.svelte` and swapping the `<path>` (Heroicons paths work
+well). Keep the `size` and `class` props.
+
+## 5. Add translations (BOTH files)
+
+Open `src/lib/translations/id.json` AND `src/lib/translations/en.json`.
+
+Add:
+
+```json
+"navigation": {
+	// ...existing
+	"<key>": "<Indonesian / English>"
+},
+"<feature>": {
+	"title": "...",
+	"subtitle": "...",
+	// any other strings used by the page
+}
+```
+
+Indonesian is the fallback locale; missing keys in `en.json` will fall
+through to `id.json`. Still add both for cleanliness.
+
+In components: `import { t } from '$lib/translations/store'` and use
+`{$t('feature.title')}` (reactive). For non-component code, import
+from `$lib/translations` instead.
+
+## 6. Verify
+
+Run all three from the repo root with Node 24+:
+
+```bash
+pnpm check        # 0 errors expected
+pnpm lint         # 0 errors expected
+pnpm build:ci     # must succeed
+```
+
+Then confirm the page is actually in the build:
+
+```bash
+ls build/<slug>/index.html
+pnpm run make:sitemap
+grep <slug> build/sitemaps/static.xml
+```
+
+If any are missing → step 2 was skipped.
+
+## 7. Manual UI check
+
+Skip this only if the page is content-only (no interactivity).
+
+```bash
+pnpm dev
+```
+
+- Visit `http://localhost:5173/<slug>/`.
+- Toggle the language (id ↔ en) — every visible string must switch.
+- Toggle theme — text must remain readable on every theme.
+- Resize to a narrow viewport (~320 px) — no horizontal scroll, no
+  layout breakage.
+- Click the drawer entry — it must navigate correctly.
+- Use the Breadcrumb to navigate back to `/`.
+
+If you cannot run the dev server (e.g. headless agent without a
+browser), state explicitly that the UI was not visually verified.
+
+## 8. Commit
+
+Conventional commit, scoped to the feature:
+
+```text
+feat(<scope>): add /<slug> page
+
+<1–3 sentence description of what and why>
+
+- Bullet of major change
+- Bullet of major change
+
+Refs #<issue>
+```
+
+The husky pre-commit hook runs `lint-staged` (prettier + eslint --fix
+on staged files). If it modifies files, re-stage and re-commit. **Do
+not** use `--no-verify`.

--- a/.claude/skills/add-translation-key/SKILL.md
+++ b/.claude/skills/add-translation-key/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: add-translation-key
+description: Add or update an i18n translation key in baca-quran.id. Use whenever the user asks to add a translation, change a label, add a new string for a UI element, or fix Indonesian/English wording. Ensures both id.json and en.json stay in sync and the key is consumed reactively.
+---
+
+# Add a translation key
+
+baca-quran.id ships two locale files. Indonesian (`id`) is the fallback
+— if a key is missing in `en.json`, the runtime falls through to
+`id.json`, then to the literal key. That fallback is silent, so it's
+easy to ship English UI with Indonesian text leaking through.
+
+## 1. Decide on namespace + key
+
+Open `src/lib/translations/id.json` and find the existing namespace
+that fits, e.g.:
+
+- `common.*` — generic UI verbs (save, cancel, loading, …)
+- `navigation.*` — drawer / menu labels
+- `surah.*` — Qur'an reader strings
+- `prayer.*` — prayer-time strings
+- `settings.*` — the settings page
+- `<feature>.*` — feature-specific (e.g. `hijri.*`, `ayahOfTheDay.*`)
+
+If none fits, create a new namespace named after the feature (camelCase).
+
+Key naming: `camelCase`, descriptive but short. Avoid sentence-shaped
+keys — they break when copy is tweaked.
+
+## 2. Add to BOTH files
+
+### `src/lib/translations/id.json`
+
+```json
+"<namespace>": {
+	"<key>": "<Indonesian text>"
+}
+```
+
+### `src/lib/translations/en.json`
+
+```json
+"<namespace>": {
+	"<key>": "<English text>"
+}
+```
+
+Same path, both files. Both are valid JSON — no trailing commas, no
+JSONC comments.
+
+If the string has variables, use `{{name}}` interpolation:
+
+```json
+"welcome": "Selamat datang, {{name}}!"
+```
+
+Then call: `t('common.welcome', { name: 'Irfan' })`.
+
+## 3. Use it in a component
+
+**Reactive (preferred for UI)** — updates when the user switches
+language without a reload:
+
+```svelte
+<script lang="ts">
+	import { t } from '$lib/translations/store';
+</script>
+
+<h1>{$t('namespace.key')}</h1>
+```
+
+**Imperative (one-shot, non-reactive)** — for module-init code,
+constants, etc. Won't update on language change:
+
+```ts
+import { t } from '$lib/translations';
+
+const TITLE = t('namespace.key');
+```
+
+For dynamic text that depends on locale at render time, prefer
+deriving from `$languageStore` directly when you need per-render
+branching that the `t` function alone can't express:
+
+```svelte
+<script lang="ts">
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+</script>
+```
+
+## 4. Verify
+
+```bash
+pnpm check     # JSON parse + svelte-check; catches typos in $t() keys
+pnpm lint      # prettier reformats id.json/en.json on save
+```
+
+Manual: `pnpm dev`, toggle the language switcher in the header,
+confirm both versions render correctly. If switching to English and
+the string still appears in Indonesian, the `en.json` entry is missing
+or misnested — check the path with the dot-notation key.
+
+## 5. Anti-patterns
+
+- ❌ Adding the key to only one file. Always both.
+- ❌ Hard-coding the string in JSX/Svelte and translating later.
+- ❌ Concatenating partial strings in code (`"Halo, " + name`). Use
+  `{{name}}` interpolation in the locale value.
+- ❌ Reusing a key with different meanings across screens. Make a new
+  one — keys are cheap.
+- ❌ Putting locale-dependent UI logic in `src/lib/utils/*` modules
+  by importing the `t` function at module load. Always call `t()`
+  inside the consumer at use-time, or accept a translated string as a
+  parameter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,352 @@
+# AGENTS.md
+
+Guide for AI coding agents (Claude Code, Cursor, Codex, Aider, etc.) working
+on this repository. Human contributors will also find it useful.
+
+## 1. Project at a glance
+
+**Baca-Quran.id** is a free, ad-free, analytics-free Qur'an reader for the
+web (https://www.baca-quran.id). SvelteKit single-page app, statically
+prerendered, deployed to GitHub Pages.
+
+### Non-negotiable philosophy
+
+- **Local-first.** State lives in `localStorage` / `IndexedDB`. No backend,
+  no DB, no server.
+- **No tracking, no ads, no analytics.** Don't add any.
+- **Optional opt-in Firebase sync** for the existing flow only — don't
+  wire new features through it.
+- **Offline-friendly.** No new third-party HTTP calls without a strong
+  reason. Prefer pure-JS solutions and shipped JSON over APIs.
+- **No new dependencies** unless a feature is impossible without them.
+  Justify additions in the PR description.
+
+If an idea contradicts the above, push back or scope it down.
+
+## 2. Tech stack
+
+| Area          | Choice                                                                       |
+| ------------- | ---------------------------------------------------------------------------- |
+| Framework     | SvelteKit 2 + **Svelte 5 runes** (`$state`, `$derived`, `$props`, `$effect`) |
+| Language      | TypeScript                                                                   |
+| Styling       | Tailwind CSS v4 (no `tailwind.config.js`; uses `@tailwindcss/postcss`)       |
+| Adapter       | `@sveltejs/adapter-static` — everything prerendered                          |
+| Dates         | `dayjs` (Gregorian); `Intl.DateTimeFormat` (Hijri)                           |
+| Optional sync | `firebase` — opt-in only                                                     |
+| Tests         | None. Verification is `check` + `lint` + `build:ci` + manual.                |
+| Package mgr   | **pnpm 10.33+**                                                              |
+| Node          | **24.14+** (see `.nvmrc`)                                                    |
+
+**Svelte 5 reminder:** use runes, not `let` reactivity / `$:` blocks.
+Component props go through `$props()`, not `export let`.
+
+## 3. Setup
+
+```bash
+# Use the pinned Node version
+nvm install   # reads .nvmrc → 24.14.1
+nvm use
+
+# Install
+pnpm install --frozen-lockfile
+
+# Dev server
+pnpm dev          # http://localhost:5173
+
+# Verify (run all three before opening a PR)
+pnpm check        # svelte-check + tsc
+pnpm lint         # prettier --check + eslint
+pnpm build:ci     # svelte-kit build (matches CI)
+```
+
+If `pnpm` complains `Unsupported environment` it means Node is < 24.14.
+`nvm use` first.
+
+The husky pre-commit hook runs `lint-staged` (prettier + eslint --fix on
+the staged files). If it fails, fix the underlying issue and re-stage —
+don't bypass with `--no-verify`.
+
+## 4. Repository layout
+
+```
+src/
+  app.css                  Tailwind entry
+  app.html                 HTML shell, theme bootstrap
+  data/                    Static, shipped JSON / TS data
+    surah-data/            Per-surah Arabic + translations
+    surah-info/            Per-surah metadata
+    daily-doa.ts           Daily prayers
+    asmaul-husna.ts
+    ayah-of-the-day.ts     Themed seed pool
+    islamic-events.ts      Hijri-date events
+  lib/                     Reusable Svelte components, stores, utils
+    icons/                 SVG icon components (one file each, consistent props)
+    translations/          i18n: id.json + en.json + reactive `t` store
+    utils/                 Pure-TS helpers (no Svelte)
+    ui/                    Generic UI primitives (Button, etc.)
+    views/                 Page-level view composites
+    *.svelte               Reusable feature components
+  routes/                  SvelteKit file-based routes
+    +layout.svelte
+    +layout.ts             prerender = true; trailingSlash = 'always'
+    +page.svelte           Home
+    <feature>/+page.svelte ...one folder per feature page
+  store/                   Cross-page Svelte stores (state + persistence)
+  service-worker.js
+scripts/
+  routes.js                Static URL list — drives BOTH prerender entries AND sitemap
+  makeSitemap.js
+  makeTimestamp.js
+  verseCountPerSurah.js
+.github/
+  workflows/ci.yml         Runs on PR: lint + check + build:ci
+  workflows/deploy.yml     Runs on push to master: build + push to gh-pages repo
+  ISSUE_TEMPLATE/          bug_report.md, feature_request.md
+```
+
+### Path aliases (configured in `svelte.config.js`)
+
+| Alias    | Maps to     | Use for                          |
+| -------- | ----------- | -------------------------------- |
+| `$lib`   | `src/lib`   | Components, utils                |
+| `$data`  | `src/data`  | Static data files                |
+| `$store` | `src/store` | Cross-page stores                |
+| `$app/*` | SvelteKit   | `$app/stores`, `$app/navigation` |
+
+## 5. Conventions cheat sheet
+
+### Adding a new page
+
+1. **Create the route**
+
+   ```text
+   src/routes/<slug>/+page.svelte
+   ```
+
+   `+page.ts` is **not required** — `src/routes/+layout.ts` already sets
+   `prerender = true` and `trailingSlash = 'always'` globally.
+
+2. **Register the URL** in `scripts/routes.js → staticUrls`. This single
+   array drives both:
+   - prerender entries in `svelte.config.js`
+   - the sitemap in `scripts/makeSitemap.js`
+
+   Forgetting this means your page won't be in the static build's entry
+   list nor in `sitemap.xml`.
+
+3. **SEO**: include `<MetaTag>` from `$lib/MetaTag.svelte` in
+   `<svelte:head>`. Add a `META_TITLE_<X>` and `META_DESC_<X>` constant
+   in `src/lib/constants.ts`.
+
+4. **Breadcrumb**: render `<Breadcrumb items={...} />` from `$lib`.
+
+5. **Drawer entry** (if user-facing nav): add a list item in
+   `src/lib/DrawerMenus.svelte` with an icon from `src/lib/icons/`. If
+   no icon fits, add a new one following the `HashtagIcon.svelte`
+   pattern (props: `size`, `class`; uses `CLASS_BY_SIZE`).
+
+6. **Translations**: add a `navigation.<key>` string and a feature
+   namespace (e.g. `myFeature.title`) to **both** `id.json` and
+   `en.json`. Indonesian is the fallback locale.
+
+7. **Verify**: `pnpm check && pnpm lint && pnpm build:ci`. Confirm
+   `build/<slug>/index.html` exists. Run `pnpm run make:sitemap` and
+   grep `build/sitemaps/static.xml` for the new URL.
+
+### Adding a new feature (general)
+
+- **Storage**: persist with `localStorage` (see `src/store/index.ts`
+  patterns and `LogPrayer*` types). Key with stable, namespaced strings.
+- **Pure logic** → `src/lib/utils/<name>.ts`. No Svelte imports.
+- **Static data** → `src/data/<name>.ts`. Type the export, freeze with
+  `as const` or `readonly`.
+- **Components** → `src/lib/<Name>.svelte`. Use Svelte 5 runes.
+- **Cross-page state** → `src/store/<name>.ts`.
+- **i18n**: every user-visible string goes through `t('namespace.key')`.
+
+### i18n (`src/lib/translations/`)
+
+- **Reactive in components**: `import { t } from '$lib/translations/store'`
+  then `{$t('namespace.key')}`. Updates on language change.
+- **Imperative**: `import { t } from '$lib/translations'` then `t('...')`.
+  Snapshot at call time — only use outside reactive contexts.
+- Add the same key to **both** `id.json` and `en.json`. Missing keys
+  fall back to Indonesian, then to the literal key.
+- Interpolation: `{{name}}` placeholders, e.g.
+  `t('common.welcome', { name: 'Irfan' })`.
+
+### Theme
+
+- Themes are listed in `src/lib/constants.ts → THEMES`.
+- The active theme is in the `activeTheme` writable store
+  (`src/store/index.ts`) and bootstrapped from `window.__theme` in
+  `app.html`.
+- Use `$activeTheme` in components; switch via
+  `window.__setActiveTheme(name)`.
+
+### Icons
+
+- Live in `src/lib/icons/`. One Svelte file per icon.
+- Pattern: copy `HashtagIcon.svelte`, swap the `<path>`. Keep the
+  `size` + `class` props and `CLASS_BY_SIZE` import.
+- Prefer Heroicons SVG paths for consistency.
+
+### Date / Hijri
+
+- Gregorian formatting: `dayjs` via `src/lib/utils/date.ts`.
+- Hijri (Umm al-Qura): `src/lib/utils/hijri.ts` —
+  `getHijriDate`, `formatHijriDate`, `hijriToGregorian`,
+  `getDaysInHijriMonth`, `shiftHijriMonth`, plus
+  `HIJRI_MONTHS_ID/EN/AR` constants.
+- Islamic events: `src/data/islamic-events.ts` with
+  `getEventsForHijriDate(month, day)`.
+- **Note**: Umm al-Qura can differ ±1 day from Indonesian rukyat
+  (Kemenag) dates around Idul Fitri / Idul Adha — surface this in UI
+  copy when relevant.
+
+## 6. Workflow: issue → PR → merge → deploy
+
+### 6.1 Pick or open an issue
+
+- Browse https://github.com/mazipan/baca-quran.id/issues for `good
+first issue`, `enhancement`, or `bug`.
+- For new ideas, use the templates in
+  `.github/ISSUE_TEMPLATE/`. Issue #404 is the local-first feature
+  brainstorm — tie new ideas back to it where applicable.
+- Comment on the issue if it's substantial — confirm scope and approach
+  before coding. For a multi-phase feature, split phases into their own
+  issues (see #408 / #409 for an example).
+
+### 6.2 Branch
+
+Branch from `master`. Naming convention used in this repo:
+
+```bash
+git checkout master
+git pull origin master
+git checkout -b claude/<short-slug>-<issue-number>
+# examples:
+#   claude/hijri-calendar-page-409
+#   claude/streak-heatmap-411
+```
+
+Other prefixes (`feat/`, `fix/`) are also fine. Whatever you pick, keep
+it lowercase, hyphenated, and reference the issue number when there is
+one.
+
+### 6.3 Implement
+
+- Stay within scope. Don't refactor surrounding files unrelated to the
+  task.
+- Don't add backwards-compatibility shims, unused exports, or "just in
+  case" abstractions.
+- Don't add comments that restate the code. Add a comment only when the
+  _why_ is non-obvious.
+- Update `id.json` AND `en.json` together when adding strings.
+- For UI: open the page in `pnpm dev`, exercise it manually. Don't
+  claim a UI task is done from a clean `pnpm check` alone.
+
+### 6.4 Verify (mandatory before commit)
+
+```bash
+pnpm check        # 0 errors expected; pre-existing warnings can stay
+pnpm lint         # 0 errors; ignore pre-existing warnings
+pnpm build:ci     # must succeed
+```
+
+For new pages, also confirm:
+
+```bash
+ls build/<slug>/index.html
+pnpm run make:sitemap
+grep <slug> build/sitemaps/static.xml
+```
+
+There is no automated test suite. Be deliberate about manual
+verification: think through edge cases, test in both `id` and `en`
+locales, test theme switching, test on a narrow viewport.
+
+### 6.5 Commit
+
+- Conventional-commit style is used in master: `feat(scope): ...`,
+  `fix(scope): ...`, `chore(deps): ...`, `ci(deps): ...`, `docs: ...`.
+- Subject line ≤ 70 chars. Body explains _why_ and references issues
+  with `Refs #N` or `Closes #N`.
+- The husky pre-commit hook runs `lint-staged`. If it modifies files,
+  re-stage and commit. **Do not** use `--no-verify`.
+- Never `git commit --amend` after a hook failure — the previous commit
+  may not be what you think it is. Make a new commit.
+- Never `git add -A` blindly. Stage explicit paths.
+
+### 6.6 Push and open a PR
+
+```bash
+git push -u origin <branch-name>
+```
+
+Then open a PR via the GitHub UI or `gh pr create`. PR body template:
+
+```markdown
+## Summary
+
+- Bullet list of what changed and why.
+
+## Verification
+
+- [ ] `pnpm check` — 0 errors
+- [ ] `pnpm lint` — 0 errors
+- [ ] `pnpm build:ci` — green
+- [ ] Manually tested in `id` and `en` locales
+- [ ] (For UI) Tested on narrow viewport
+
+Refs #<issue>
+```
+
+CI (`.github/workflows/ci.yml`) runs `lint`, `check`, `build:ci` on
+every PR. All three must pass before merge.
+
+**Do not** open a PR unless the user explicitly asks for one.
+
+### 6.7 Merge and deploy
+
+- The repo owner squash-merges into `master`.
+- `.github/workflows/deploy.yml` triggers on master push and publishes
+  to GitHub Pages. Nothing for the contributor to do.
+
+## 7. CI / GitHub Actions
+
+| Workflow                | Trigger        | Does                                         |
+| ----------------------- | -------------- | -------------------------------------------- |
+| `ci.yml`                | PR open / sync | lint, check, build:ci                        |
+| `deploy.yml`            | push to master | build, push static site to Pages             |
+| `dependabot.yml`        | scheduled      | dep updates                                  |
+| `rotate-ayah-seed.yml`  | scheduled      | rotates `ayah-of-the-day-seeds.json`         |
+| `switch-ayah-theme.yml` | scheduled      | switches `ayah-of-the-day-config.json` theme |
+
+## 8. Anti-patterns to avoid
+
+- ❌ Adding a backend, REST endpoint, or external API call for state
+  that could live in `localStorage`.
+- ❌ Adding analytics, tracking, ads, or third-party scripts.
+- ❌ Adding npm dependencies for things the platform / `Intl` already
+  does (date math, formatting).
+- ❌ Using `export let` (Svelte 4) — this codebase is on Svelte 5
+  runes.
+- ❌ Hard-coded user-visible strings — must go through `t()`.
+- ❌ Touching the deploy workflow or `mazipan-quran-offline/*` — only
+  the maintainer publishes.
+- ❌ Skipping git hooks (`--no-verify`, `--no-gpg-sign`).
+- ❌ `git push --force` to a branch someone else may have based work
+  on. Force-pushing your own feature branch is fine when needed.
+- ❌ Renaming or deleting routes without first checking
+  `scripts/routes.js`, the sitemap, and any inbound links / drawer
+  entries.
+
+## 9. When unsure
+
+- Read the matching existing file. The first PR for a Hijri feature
+  (#410) and the calendar page (#411 series) are both worth skimming
+  for the "feature page" pattern.
+- Read `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`.
+- Comment on the issue and ask. Better to clarify scope before writing
+  code than to get a "not what I wanted" review.

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -6,6 +6,7 @@ export const staticUrls = [
 	'/daily-doa',
 	'/jadwal-sholat',
 	'/juz-amma',
+	'/kalender-hijriyah',
 	'/kebijakan-privasi',
 	'/ketentuan-layanan',
 	'/settings',

--- a/src/lib/DrawerMenus.svelte
+++ b/src/lib/DrawerMenus.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { t } from './translations/store';
+	import CalendarIcon from './icons/CalendarIcon.svelte';
 	import HashtagIcon from './icons/HashtagIcon.svelte';
 	import HomeIcon from './icons/HomeIcon.svelte';
 	import InformationCircleIcon from './icons/InformationCircleIcon.svelte';
@@ -26,6 +27,16 @@
 		>
 			<SettingIcon />
 			{$t('navigation.settings')}
+		</a>
+	</li>
+	<li class="sidebar__item">
+		<a
+			data-sveltekit-reload
+			href="/kalender-hijriyah/"
+			class="flex gap-2 items-center p-2 rounded-md hover:bg-primary focus:bg-primary"
+		>
+			<CalendarIcon />
+			{$t('navigation.hijriCalendar')}
 		</a>
 	</li>
 	<li class="sidebar__item">

--- a/src/lib/HijriCalendar.svelte
+++ b/src/lib/HijriCalendar.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import { languageStore, LANGUAGE_OPTIONS } from './checkLanguaguage';
+	import { t } from './translations/store';
+	import {
+		HIJRI_MONTHS_ID,
+		HIJRI_MONTHS_EN,
+		getDaysInHijriMonth,
+		getHijriDate,
+		hijriToGregorian,
+		shiftHijriMonth
+	} from './utils/hijri';
+	import { getEventsForHijriDate, type IslamicEvent } from '$data/islamic-events';
+	import ChevronRightIcon from './icons/ChevronRightIcon.svelte';
+
+	interface Props {
+		year: number;
+		month: number;
+		onNavigate: (year: number, month: number) => void;
+	}
+
+	let { year, month, onNavigate }: Props = $props();
+
+	type Cell = {
+		hijriDay: number;
+		gregorian: Date;
+		isToday: boolean;
+		events: IslamicEvent[];
+	};
+
+	const today = new Date();
+	const todayHijri = getHijriDate(today);
+
+	let isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	let monthName = $derived((isEnglish ? HIJRI_MONTHS_EN : HIJRI_MONTHS_ID)[month - 1]);
+
+	let firstDayGregorian = $derived(hijriToGregorian(year, month, 1));
+	let leadingBlanks = $derived(firstDayGregorian.getDay());
+	let daysInMonth = $derived(getDaysInHijriMonth(year, month));
+
+	let cells = $derived.by<Cell[]>(() => {
+		const list: Cell[] = [];
+		const firstMs = firstDayGregorian.getTime();
+		for (let d = 1; d <= daysInMonth; d++) {
+			const greg = new Date(firstMs + (d - 1) * 86_400_000);
+			list.push({
+				hijriDay: d,
+				gregorian: greg,
+				isToday: todayHijri.year === year && todayHijri.month === month && todayHijri.day === d,
+				events: getEventsForHijriDate(month, d)
+			});
+		}
+		return list;
+	});
+
+	let weekdayLabels = $derived.by<string[]>(() => {
+		const locale = isEnglish ? 'en-US' : 'id-ID';
+		const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+		// 2024-01-07 was a Sunday — produces locale-correct Sun..Sat order.
+		const sunday = new Date(Date.UTC(2024, 0, 7));
+		return Array.from({ length: 7 }, (_, i) => {
+			const d = new Date(sunday.getTime() + i * 86_400_000);
+			return fmt.format(d);
+		});
+	});
+
+	function eventColor(type: IslamicEvent['type']): string {
+		if (type === 'holiday') return 'bg-red-500';
+		if (type === 'fasting') return 'bg-green-500';
+		return 'bg-blue-500';
+	}
+
+	function eventName(e: IslamicEvent): string {
+		return isEnglish ? e.nameEn : e.nameId;
+	}
+
+	function goPrev() {
+		const next = shiftHijriMonth(year, month, -1);
+		onNavigate(next.year, next.month);
+	}
+	function goNext() {
+		const next = shiftHijriMonth(year, month, 1);
+		onNavigate(next.year, next.month);
+	}
+	function goToday() {
+		onNavigate(todayHijri.year, todayHijri.month);
+	}
+</script>
+
+<div class="flex flex-col gap-4">
+	<div class="flex items-center justify-between gap-2">
+		<button
+			type="button"
+			class="cursor-pointer p-2 rounded-md hover:bg-secondary focus:bg-secondary"
+			onclick={goPrev}
+			aria-label={$t('hijriCalendar.prevMonth')}
+		>
+			<span class="inline-block rotate-180"><ChevronRightIcon /></span>
+		</button>
+
+		<div class="flex flex-col items-center text-center">
+			<span class="text-xl font-bold">{monthName} {year} {isEnglish ? 'AH' : 'H'}</span>
+			<button
+				type="button"
+				class="text-xs underline cursor-pointer text-foreground-secondary hover:text-foreground"
+				onclick={goToday}
+			>
+				{$t('hijriCalendar.today')}
+			</button>
+		</div>
+
+		<button
+			type="button"
+			class="cursor-pointer p-2 rounded-md hover:bg-secondary focus:bg-secondary"
+			onclick={goNext}
+			aria-label={$t('hijriCalendar.nextMonth')}
+		>
+			<ChevronRightIcon />
+		</button>
+	</div>
+
+	<div class="grid grid-cols-7 gap-1 text-center text-xs font-semibold opacity-75">
+		{#each weekdayLabels as label, i (i)}
+			<div class="py-1">{label}</div>
+		{/each}
+	</div>
+
+	<div class="grid grid-cols-7 gap-1">
+		{#each Array(leadingBlanks) as _, i (`b-${i}`)}
+			<div></div>
+		{/each}
+		{#each cells as cell (cell.hijriDay)}
+			<div
+				class="aspect-square flex flex-col items-center justify-center rounded-md p-1 text-sm bg-secondary"
+				class:ring-2={cell.isToday}
+				class:ring-blue-500={cell.isToday}
+				title={cell.events.length > 0 ? cell.events.map(eventName).join(', ') : undefined}
+			>
+				<span class="font-bold leading-none">{cell.hijriDay}</span>
+				<span class="text-[10px] leading-none mt-0.5 opacity-60">
+					{cell.gregorian.getDate()}
+				</span>
+				{#if cell.events.length > 0}
+					<div class="flex gap-0.5 mt-1">
+						{#each cell.events as e (e.id)}
+							<span
+								class={`inline-block w-1.5 h-1.5 rounded-full ${eventColor(e.type)}`}
+								aria-hidden="true"
+							></span>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/HijriDate.svelte
+++ b/src/lib/HijriDate.svelte
@@ -38,8 +38,9 @@
 </script>
 
 {#if hijri}
-	<div
-		class="hidden sm:flex items-center gap-1.5 text-sm select-none"
+	<a
+		href="/kalender-hijriyah/"
+		class="hidden sm:flex items-center gap-1.5 text-sm select-none px-2 py-1 rounded-md hover:bg-secondary focus:bg-secondary"
 		title={tooltip}
 		aria-label={tooltip}
 	>
@@ -52,5 +53,5 @@
 				aria-hidden="true"
 			></span>
 		{/if}
-	</div>
+	</a>
 {/if}

--- a/src/lib/icons/CalendarIcon.svelte
+++ b/src/lib/icons/CalendarIcon.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { CLASS_BY_SIZE, type IconSize } from './utils';
+
+	interface Props {
+		size?: IconSize;
+		class?: string;
+	}
+
+	let { size = 'md', class: clazz }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width="1.5"
+	stroke="currentColor"
+	class={clazz || CLASS_BY_SIZE[size]}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
+	/>
+</svg>

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -35,7 +35,8 @@
 		"settings": "Settings",
 		"sync": "Sync",
 		"about": "About",
-		"ayatOfTheDay": "AyatOfTheDay"
+		"ayatOfTheDay": "AyatOfTheDay",
+		"hijriCalendar": "Hijri Calendar"
 	},
 	"surah": {
 		"title": "Read Quran",
@@ -102,5 +103,14 @@
 	"hijri": {
 		"suffix": "AH",
 		"todayEvent": "Today"
+	},
+	"hijriCalendar": {
+		"title": "Hijri Calendar",
+		"subtitle": "Hijri calendar with Gregorian dates and Islamic holidays",
+		"eventsThisMonth": "Events This Month",
+		"noEvents": "No Islamic events this month.",
+		"today": "Today",
+		"prevMonth": "Previous month",
+		"nextMonth": "Next month"
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -35,7 +35,8 @@
 		"settings": "Setelan",
 		"sync": "Sinkron",
 		"about": "Tentang",
-		"ayatOfTheDay": "AyatHariIni"
+		"ayatOfTheDay": "AyatHariIni",
+		"hijriCalendar": "Kalender Hijriyah"
 	},
 	"surah": {
 		"title": "Baca Qur'an",
@@ -102,5 +103,14 @@
 	"hijri": {
 		"suffix": "H",
 		"todayEvent": "Hari ini"
+	},
+	"hijriCalendar": {
+		"title": "Kalender Hijriyah",
+		"subtitle": "Kalender Hijriyah dengan tanggal Masehi dan hari besar Islam",
+		"eventsThisMonth": "Hari Besar Bulan Ini",
+		"noEvents": "Tidak ada hari besar di bulan ini.",
+		"today": "Hari Ini",
+		"prevMonth": "Bulan sebelumnya",
+		"nextMonth": "Bulan berikutnya"
 	}
 }

--- a/src/lib/utils/hijri.ts
+++ b/src/lib/utils/hijri.ts
@@ -87,3 +87,62 @@ export function formatHijriDate(d: Date, locale: 'id' | 'en'): string {
 	const suffix = locale === 'en' ? 'AH' : 'H';
 	return `${day} ${months[month - 1]} ${year} ${suffix}`;
 }
+
+const MS_PER_DAY = 86_400_000;
+// 1 Muharram 1 AH ≈ 16 July 622 CE (Julian) → ~19 July 622 CE Gregorian.
+// Used only as a starting estimate for the bisection.
+const HIJRI_EPOCH_MS = Date.UTC(622, 6, 19);
+// Mean Hijri year length, used only for the initial estimate.
+const MEAN_HIJRI_YEAR_DAYS = 354.367;
+
+/**
+ * Normalize a Hijri (year, month) pair after applying ±delta months.
+ * Months are in 1–12 range.
+ */
+export function shiftHijriMonth(
+	year: number,
+	month: number,
+	delta: number
+): { year: number; month: number } {
+	const total = year * 12 + (month - 1) + delta;
+	const y = Math.floor(total / 12);
+	const m = total - y * 12 + 1;
+	return { year: y, month: m };
+}
+
+/**
+ * Find the Gregorian Date corresponding to a given Hijri (Umm al-Qura) Y/M/D.
+ * Bisection over Gregorian dates using getHijriDate(); ~25 Intl calls.
+ */
+export function hijriToGregorian(year: number, month: number, day: number): Date {
+	const cmp = (h: { year: number; month: number; day: number }): number => {
+		if (h.year !== year) return h.year - year;
+		if (h.month !== month) return h.month - month;
+		return h.day - day;
+	};
+	const estDays = Math.round((year - 1) * MEAN_HIJRI_YEAR_DAYS + (month - 1) * 29.5 + (day - 1));
+	const estimateMs = HIJRI_EPOCH_MS + estDays * MS_PER_DAY;
+	let lo = estimateMs - 365 * MS_PER_DAY;
+	let hi = estimateMs + 365 * MS_PER_DAY;
+	while (cmp(getHijriDate(new Date(lo))) > 0) lo -= 365 * MS_PER_DAY;
+	while (cmp(getHijriDate(new Date(hi))) < 0) hi += 365 * MS_PER_DAY;
+	while (lo <= hi) {
+		const midDays = Math.floor((lo + hi) / (2 * MS_PER_DAY));
+		const mid = midDays * MS_PER_DAY;
+		const c = cmp(getHijriDate(new Date(mid)));
+		if (c === 0) return new Date(mid);
+		if (c < 0) lo = mid + MS_PER_DAY;
+		else hi = mid - MS_PER_DAY;
+	}
+	return new Date(lo);
+}
+
+/**
+ * Number of days in a given Hijri month (Umm al-Qura): 29 or 30.
+ */
+export function getDaysInHijriMonth(year: number, month: number): number {
+	const next = shiftHijriMonth(year, month, 1);
+	const a = hijriToGregorian(year, month, 1);
+	const b = hijriToGregorian(next.year, next.month, 1);
+	return Math.round((b.getTime() - a.getTime()) / MS_PER_DAY);
+}

--- a/src/routes/kalender-hijriyah/+page.svelte
+++ b/src/routes/kalender-hijriyah/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Breadcrumb from '$lib/Breadcrumb.svelte';
+	import MetaTag from '$lib/MetaTag.svelte';
+	import HijriCalendar from '$lib/HijriCalendar.svelte';
+	import { TITLE_CONSTANTS } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import { t } from '$lib/translations/store';
+	import { ISLAMIC_EVENTS, type IslamicEvent } from '$data/islamic-events';
+	import { getHijriDate } from '$lib/utils/hijri';
+
+	const today = new Date();
+	const todayHijri = getHijriDate(today);
+
+	let year = $state(todayHijri.year);
+	let month = $state(todayHijri.month);
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	const eventsThisMonth = $derived(
+		ISLAMIC_EVENTS.filter((e) => e.hijriMonth === month)
+			.slice()
+			.sort((a, b) => a.hijriDay - b.hijriDay)
+	);
+
+	function eventName(e: IslamicEvent): string {
+		return isEnglish ? e.nameEn : e.nameId;
+	}
+
+	function eventTypeLabel(e: IslamicEvent): string {
+		const map: Record<IslamicEvent['type'], { id: string; en: string }> = {
+			holiday: { id: 'Hari Besar', en: 'Holiday' },
+			fasting: { id: 'Puasa', en: 'Fasting' },
+			observance: { id: 'Peringatan', en: 'Observance' }
+		};
+		const v = map[e.type];
+		return isEnglish ? v.en : v.id;
+	}
+
+	function eventTypeColor(type: IslamicEvent['type']): string {
+		if (type === 'holiday') return 'bg-red-500';
+		if (type === 'fasting') return 'bg-green-500';
+		return 'bg-blue-500';
+	}
+
+	function navigate(y: number, m: number) {
+		year = y;
+		month = m;
+		if (typeof window !== 'undefined' && window.history) {
+			const url = new URL(window.location.href);
+			url.searchParams.set('m', `${y}-${String(m).padStart(2, '0')}`);
+			window.history.replaceState({}, '', url.toString());
+		}
+	}
+
+	onMount(() => {
+		const params = new URLSearchParams(window.location.search);
+		const m = params.get('m');
+		if (m) {
+			const match = /^(\d{3,4})-(0?[1-9]|1[0-2])$/.exec(m);
+			if (match) {
+				year = Number(match[1]);
+				month = Number(match[2]);
+			}
+		}
+	});
+
+	const META_TITLE = `Kalender Hijriyah & Hari Besar Islam | ${TITLE_CONSTANTS.TITLE_META}`;
+	const META_DESC =
+		'Kalender Hijriyah online lengkap dengan tanggal Masehi dan hari besar Islam seperti Idul Fitri, Idul Adha, Maulid Nabi, Isra Mi’raj, dan Ramadan. Gratis, tanpa iklan, tanpa analitik.';
+</script>
+
+<svelte:head>
+	<MetaTag title={META_TITLE} desc={META_DESC} url={`${TITLE_CONSTANTS.PATH}kalender-hijriyah/`} />
+</svelte:head>
+
+<div class="flex gap-2 px-4 mb-4">
+	<h1 class="text-3xl font-bold">
+		🌙 {isEnglish ? 'Hijri Calendar' : 'Kalender Hijriyah'}
+	</h1>
+</div>
+
+<div class="px-4 mb-4">
+	<Breadcrumb
+		items={[
+			{ text: isEnglish ? '🏠 Home' : '🏠 Beranda', href: '/' },
+			{ text: isEnglish ? 'Hijri Calendar' : 'Kalender Hijriyah', href: '/kalender-hijriyah/' }
+		]}
+	/>
+</div>
+
+<div class="px-4 flex flex-col gap-6">
+	<HijriCalendar {year} {month} onNavigate={navigate} />
+
+	<section class="flex flex-col gap-2">
+		<h2 class="text-xl font-bold">
+			{$t('hijriCalendar.eventsThisMonth')}
+		</h2>
+
+		{#if eventsThisMonth.length === 0}
+			<p class="text-sm opacity-75">{$t('hijriCalendar.noEvents')}</p>
+		{:else}
+			<ul class="flex flex-col gap-2">
+				{#each eventsThisMonth as e (e.id)}
+					<li
+						class="flex items-center gap-3 p-3 rounded-md bg-secondary"
+						class:ring-2={todayHijri.year === year &&
+							todayHijri.month === month &&
+							todayHijri.day === e.hijriDay}
+						class:ring-blue-500={todayHijri.year === year &&
+							todayHijri.month === month &&
+							todayHijri.day === e.hijriDay}
+					>
+						<span class="font-bold text-lg w-8 text-center">{e.hijriDay}</span>
+						<div class="flex flex-col flex-1">
+							<span class="font-semibold">{eventName(e)}</span>
+							<span class="text-xs opacity-75">{eventTypeLabel(e)}</span>
+						</div>
+						<span
+							class={`inline-block w-2 h-2 rounded-full ${eventTypeColor(e.type)}`}
+							aria-hidden="true"
+						></span>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	<p class="text-xs opacity-60">
+		{isEnglish
+			? 'Dates use the Umm al-Qura calendar and may differ by ±1 day from official Indonesian government (rukyat-based) dates, especially for Eid al-Fitr and Eid al-Adha.'
+			: 'Tanggal menggunakan kalender Umm al-Qura dan dapat berbeda ±1 hari dari penetapan resmi pemerintah Indonesia (rukyat), khususnya pada Idul Fitri dan Idul Adha.'}
+	</p>
+</div>


### PR DESCRIPTION
Phase 2 of #404 (item #12). Adds a dedicated Hijri calendar page that
the Header HijriDate label now links into. Pure offline, no API, no
new deps.

- Extend src/lib/utils/hijri.ts with getDaysInHijriMonth,
  hijriToGregorian (bisection over Intl), shiftHijriMonth.
- New src/lib/HijriCalendar.svelte: 7-column month grid with locale
  weekday headers, Hijri/Gregorian dual day labels, per-day event
  dots, prev/next/today navigation.
- New src/routes/kalender-hijriyah/+page.svelte: page shell with
  breadcrumb, MetaTag SEO, event list panel for the visible month,
  and a footnote about Umm al-Qura vs Indonesian rukyat dates. Reads
  the month from ?m=YYYY-MM on mount and writes it back via
  history.replaceState so deep-links and back-button work.
- Drawer menu entry + new CalendarIcon.
- HijriDate label in Header is now an <a> linking to
  /kalender-hijriyah/.
- scripts/routes.js: add /kalender-hijriyah to staticUrls so the
  build prerenders it and the sitemap picks it up.
- Translations: navigation.hijriCalendar + hijriCalendar.* keys in
  id/en.

Refs #409