### PR TITLE
fix: resolve pnpm run lint errors and warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,14 @@ export default [
 			...typescript.configs.recommended.rules,
 			'svelte/no-at-html-tags': 'off',
 			'@typescript-eslint/no-explicit-any': 'warn',
-			'@typescript-eslint/no-unused-vars': 'warn',
+			'@typescript-eslint/no-unused-vars': [
+				'warn',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			],
 			'@typescript-eslint/no-unused-expressions': 'warn'
 		}
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
+        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
         version: 7.0.1(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@7.3.2(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@7.3.2(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3)))
@@ -2081,9 +2081,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.3.0(jiti@2.6.1))':
+  '@eslint/js@10.0.1(eslint@10.3.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.3.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 

--- a/src/lib/SurahList.svelte
+++ b/src/lib/SurahList.svelte
@@ -24,7 +24,6 @@
 		if (searchText.length > 1) {
 			let result: SurahInfo = {};
 
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			for (const [_, surah] of Object.entries(originSurahInfo)) {
 				if (
 					noSpecialChars(surah.latin.toLowerCase()).indexOf(

--- a/src/lib/TranslationExample.svelte
+++ b/src/lib/TranslationExample.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
 	import { t } from './translations/store';
-	import { createNamespaceStore } from './translations/store';
-
-	// Example of using namespace store
-	const commonTranslations = createNamespaceStore('common');
-	const navigationTranslations = createNamespaceStore('navigation');
 </script>
 
 <div class="p-4 space-y-4">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,7 +39,7 @@ export interface PrayerCal {
 	month: PrayerCalMonth;
 	year: string;
 	designation: PrayerDesignation;
-	holidays?: any[];
+	holidays?: string[];
 }
 
 export interface PrayerCalWeekday {

--- a/src/lib/utils/audio.ts
+++ b/src/lib/utils/audio.ts
@@ -1,14 +1,12 @@
 export const makeThreeDigit = (numberText: string) => {
-	let res = '000';
 	const numParam = parseInt(numberText, 10);
 	if (numParam < 10) {
-		res = `00${numberText}`;
-	} else if (numParam >= 10 && numParam < 100) {
-		res = `0${numberText}`;
-	} else {
-		res = `${numberText}`;
+		return `00${numberText}`;
 	}
-	return res;
+	if (numParam < 100) {
+		return `0${numberText}`;
+	}
+	return `${numberText}`;
 };
 
 export type ReciterKey = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';

--- a/src/lib/views/VersePage.svelte
+++ b/src/lib/views/VersePage.svelte
@@ -12,6 +12,7 @@
 	import { t } from '$lib/translations/store';
 
 	interface Props {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		data: any;
 	}
 

--- a/src/routes/jadwal-sholat/+page.svelte
+++ b/src/routes/jadwal-sholat/+page.svelte
@@ -18,7 +18,6 @@
 	import { toast } from '../../store/toast';
 	import PrayerTimeList from '$lib/PrayerTimeList.svelte';
 	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
-	import type { Writable } from 'svelte/store';
 
 	const BASE_URL = 'https://api.aladhan.com/v1/calendar';
 	let prayerTimes: PrayerTimeData[] = $state([]);
@@ -95,7 +94,7 @@
 			);
 			const res = await resRaw.json();
 			return res?.address?.city_district || '';
-		} catch (error) {
+		} catch (_error) {
 			console.error(`Failed get distric for lat: ${latitude}, long: ${longitude}`);
 			return '';
 		}

--- a/src/routes/juz-amma/+page.svelte
+++ b/src/routes/juz-amma/+page.svelte
@@ -13,7 +13,6 @@
 
 	function insertMakkiyahMadaniyah() {
 		let result: SurahInfo = {};
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		for (const [_, surah] of Object.entries(surahInfo)) {
 			if (surah.index >= SURAH_START) {
 				result[surah.index] = {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -8,10 +8,20 @@
 	import surahData from '../../data/surah-data/108';
 	import { settingAudio, settingAutoNext, settingTafsir, settingTranslation } from '../../store';
 	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+
+	type SurahSampleEntry = {
+		text: Record<string, string>;
+		translations: { id: { text: Record<string, string> } };
+		tafsir: { id: { kemenag: { text: Record<string, string> } } };
+	};
+
 	let SURAH_SAMPLE = 108;
 	let SURAH_SAMPLE_TOTAL_AYAH = 3;
 	let SURAH_SAMPLE_ARABIC = 'الكوثر';
 	let SURAH_SAMPLE_LATIN = 'Al-Kausar';
+	const sample = (surahData as unknown as Record<string, SurahSampleEntry>)[
+		SURAH_SAMPLE.toString()
+	];
 	const current = $derived(languageStore);
 </script>
 
@@ -99,16 +109,12 @@
 			<b>Preview</b>
 			<div>
 				<div class="mt-2 flex flex-col gap-1">
-					{#each Object.entries((surahData as any)[SURAH_SAMPLE.toString()].text) as [numberVerse, verse] (`${SURAH_SAMPLE}-${numberVerse}`)}
+					{#each Object.entries(sample.text) as [numberVerse, verse] (`${SURAH_SAMPLE}-${numberVerse}`)}
 						<VerseCard
 							verse={`${verse}`}
 							{numberVerse}
-							translation={(surahData as any)[SURAH_SAMPLE.toString()]?.translations.id?.text?.[
-								numberVerse
-							] || ''}
-							tafsir={(surahData as any)[SURAH_SAMPLE.toString()]?.tafsir?.id?.kemenag?.text?.[
-								numberVerse
-							] || ''}
+							translation={sample?.translations.id?.text?.[numberVerse] || ''}
+							tafsir={sample?.tafsir?.id?.kemenag?.text?.[numberVerse] || ''}
 							numberSurah={SURAH_SAMPLE.toString()}
 							totalAyah={SURAH_SAMPLE_TOTAL_AYAH}
 							source="surah"

--- a/src/routes/surah-madaniyah/+page.svelte
+++ b/src/routes/surah-madaniyah/+page.svelte
@@ -9,7 +9,6 @@
 
 	function filterOnlyMadaniyah() {
 		let result: SurahInfo = {};
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		for (const [_, surah] of Object.entries(surahInfo)) {
 			if (MakkiyahMadaniyah[surah.index] === MADANIYAH_CODE) {
 				result[surah.index] = {

--- a/src/routes/surah-makkiyah/+page.svelte
+++ b/src/routes/surah-makkiyah/+page.svelte
@@ -9,7 +9,6 @@
 
 	function filterOnlyMakkiyah() {
 		let result: SurahInfo = {};
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		for (const [_, surah] of Object.entries(surahInfo)) {
 			if (MakkiyahMadaniyah[surah.index] === MAKKIYAH_CODE) {
 				result[surah.index] = {

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -12,7 +12,7 @@ function createToast() {
 		message: '',
 		type: 'info'
 	});
-	let timer: any;
+	let timer: ReturnType<typeof setTimeout> | undefined;
 
 	return {
 		subscribe,


### PR DESCRIPTION
Fix the no-useless-assignment error in audio.ts and clean up the
remaining warnings so pnpm run lint exits cleanly. Configure
@typescript-eslint/no-unused-vars to honor the underscore-prefix
convention, replace any types with specific ones where safe, and
remove unused imports.