### PR TITLE
i18n: route aria-label attributes through translation system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,14 +166,58 @@ scripts/
 
 ### i18n (`src/lib/translations/`)
 
-- **Reactive in components**: `import { t } from '$lib/translations/store'`
-  then `{$t('namespace.key')}`. Updates on language change.
-- **Imperative**: `import { t } from '$lib/translations'` then `t('...')`.
-  Snapshot at call time — only use outside reactive contexts.
-- Add the same key to **both** `id.json` and `en.json`. Missing keys
-  fall back to Indonesian, then to the literal key.
+Full guide: `src/lib/translations/README.md`. Key rules:
+
+- **Reactive in templates**: `import { t } from '$lib/translations/store'`
+  then `{$t('namespace.key')}`. Re-renders on language change.
+- **Imperative in handlers**: `import { t as translate } from '$lib/translations'`
+  then `translate('...')`. Reads language at call time — use inside event
+  handlers and `async` functions where `$t` is not available.
+- If a component needs both, import both under different names:
+  ```svelte
+  import { t } from '$lib/translations/store';        // template
+  import { t as translate } from '$lib/translations'; // handlers
+  ```
+- Add the same key to **both** `id.json` and `en.json` in the same commit.
+  Missing keys fall back to Indonesian silently.
 - Interpolation: `{{name}}` placeholders, e.g.
   `t('common.welcome', { name: 'Irfan' })`.
+- **Reuse before adding.** Check both JSON files before creating a new key.
+  Commonly reusable: `navigation.home`, `common.close`, `settings.translation`,
+  `surah.share*`.
+- **Never** use inline locale ternaries — they bypass the system and break
+  reactivity:
+  ```svelte
+  <!-- ❌ -->
+  {current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Settings' : 'Setelan'}
+  <!-- ✅ -->
+  {$t('settings.title')}
+  ```
+  After removing a ternary, check whether `LANGUAGE_OPTIONS` / `languageStore` /
+  `current` are still needed in that file; remove them if not.
+
+#### i18n verification (run after every translation change)
+
+```bash
+# 1. Key exists in both files
+grep -n "yourNewKey" src/lib/translations/id.json src/lib/translations/en.json
+
+# 2. No inline locale ternaries remain
+grep -rn "LANGUAGE_OPTIONS.ENGLISH.locale ?" src/routes/ src/lib/
+
+# 3. No leftover unused imports in files you touched
+grep -n "LANGUAGE_OPTIONS\|languageStore\|current ==" src/routes/YOUR_FILE.svelte
+
+# 4. Formatting
+pnpm lint
+
+# 5. Types
+pnpm check
+```
+
+After deploying (or in `pnpm dev`): switch the language with the globe icon and
+confirm every changed string updates without a page reload. Toast messages should
+appear in the active language on the next trigger.
 
 ### Theme
 
@@ -261,6 +305,9 @@ ls build/<slug>/index.html
 pnpm run make:sitemap
 grep <slug> build/sitemaps/static.xml
 ```
+
+For any translation change, also run the **i18n verification** steps in
+§5 → "i18n verification" above.
 
 There is no automated test suite. Be deliberate about manual
 verification: think through edge cases, test in both `id` and `en`

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -2,6 +2,7 @@
 	import LanguageChanger from './LanguageChanger.svelte';
 	import ThemeSwicther from './ThemeSwicther.svelte';
 	import HijriDate from './HijriDate.svelte';
+	import { t } from './translations/store';
 
 	interface Props {
 		onToggleDrawer: () => void;
@@ -14,7 +15,7 @@
 	<button
 		class="cursor-pointer p-2 rounded-md hover:bg-secondary focus:bg-secondary"
 		onclick={onToggleDrawer}
-		aria-label="Toggle Drawer"
+		aria-label={$t('aria.toggleDrawer')}
 	>
 		<svg
 			xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/LanguageChanger.svelte
+++ b/src/lib/LanguageChanger.svelte
@@ -2,6 +2,7 @@
 	import { CheckLanguage, LANGUAGE_OPTIONS, languageStore } from './checkLanguaguage';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import { t } from './translations/store';
 
 	let showOptions = false;
 	let currentLang: 'id' | 'en' = LANGUAGE_OPTIONS.INDONESIAN.locale; // Default value for SSR
@@ -30,7 +31,7 @@
 		id="language-button"
 		aria-expanded={showOptions}
 		aria-haspopup="true"
-		aria-label="Change Language"
+		aria-label={$t('aria.changeLanguage')}
 		onclick={() => (showOptions = !showOptions)}
 	>
 		<svg

--- a/src/lib/ThemeSwicther.svelte
+++ b/src/lib/ThemeSwicther.svelte
@@ -4,6 +4,7 @@
 
 	import { onMount } from 'svelte';
 	import { activeTheme } from '../store';
+	import { t } from './translations/store';
 	let show = $state(false);
 
 	const handleSwitchTheme = (theme: string) => {
@@ -32,7 +33,7 @@
 			aria-expanded={show}
 			aria-haspopup="true"
 			onclick={() => (show = !show)}
-			aria-label="Switch Theme"
+			aria-label={$t('aria.switchTheme')}
 		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/Toaster.svelte
+++ b/src/lib/Toaster.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import XMarkIcon from './icons/XMarkIcon.svelte';
 	import { toast } from '../store/toast';
+	import { t } from './translations/store';
 	import FireIcon from './icons/FireIcon.svelte';
 	import CheckCircleIcon from './icons/CheckCircleIcon.svelte';
 	import ExclamationTriangleIcon from './icons/ExclamationTriangleIcon.svelte';
@@ -46,7 +47,7 @@
 			type="button"
 			class="ml-3 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700"
 			data-dismiss-target="#toast-message"
-			aria-label="Close"
+			aria-label={$t('common.close')}
 			onclick={handleClose}
 		>
 			<XMarkIcon />

--- a/src/lib/VerseShareBottomSheet.svelte
+++ b/src/lib/VerseShareBottomSheet.svelte
@@ -4,8 +4,7 @@
 	import Button from './ui/Button.svelte';
 	import ShareIcon from './icons/ShareIcon.svelte';
 	import LinkIcon from './icons/LinkIcon.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from './checkLanguaguage';
-	const current = $derived(languageStore);
+	import { t } from './translations/store';
 
 	const handleShareVerse = () => {
 		verseShareSheet.share({
@@ -31,11 +30,11 @@
 	<div class="p-4 flex flex-col gap-4">
 		<Button onClick={handleShareVerse}>
 			<ShareIcon size="sm" />
-			{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Share Verse' : 'Bagikan Ayat'}
+			{$t('surah.shareVerse')}
 		</Button>
 		<Button onClick={handleShareTranslation}>
 			<ShareIcon size="sm" />
-			{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Share Translation' : 'Bagikan Terjemahan'}
+			{$t('surah.shareTranslation')}
 		</Button>
 		<a
 			href={`/surah/${$verseShareSheet.numberSurah}/${$verseShareSheet.numberVerse}/`}
@@ -43,7 +42,7 @@
 			data-sveltekit-reload
 		>
 			<LinkIcon size="sm" />
-			{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Visit Verse Link' : 'Kunjungi Tautan Ayat'}
+			{$t('surah.visitVerseLink')}
 		</a>
 	</div>
 </BottomSheet>

--- a/src/lib/translations/README.md
+++ b/src/lib/translations/README.md
@@ -6,101 +6,195 @@ This directory contains the translation system for the Baca Quran application. I
 
 ```
 translations/
-├── index.ts          # Main translation utilities
+├── index.ts          # Main translation utilities (imperative)
 ├── store.ts          # Svelte stores for reactive translations
 ├── id.json           # Indonesian translations
 ├── en.json           # English translations
 └── README.md         # This file
 ```
 
+---
+
 ## Usage
 
-### Basic Translation
+### Reactive template use (`$t`)
+
+For text rendered inside Svelte templates, import the store version and use `$t`:
 
 ```svelte
 <script>
-	import { t } from './translations/store';
+	import { t } from '$lib/translations/store';
 </script>
 
-<p>{$t('common.loading')}</p><p>{$t('surah.title')}</p>
+<p>{$t('common.loading')}</p><h1>{$t('surah.title')}</h1>
 ```
 
-### With Parameters
+### Imperative use inside event handlers and async functions
+
+When calling `t()` inside a `<script>` block function (event handler, async callback, etc.), import the **imperative** variant from the index file. It reads the current language via `get(languageStore)` at call time:
 
 ```svelte
 <script>
-	import { t } from './translations/store';
-</script>
+	import { t as translate } from '$lib/translations';
 
-<p>{$t('common.welcome', { name: 'John' })}</p>
+	async function handleAction() {
+		// Correct: reads language at the moment the function runs
+		toast.show({ message: translate('sync.uploadSuccess'), type: 'success' });
+	}
+</script>
 ```
 
-### Namespace Stores
+> **Why two variants?**  
+> `$t` in a template is an auto-subscribed Svelte store that re-renders when the language changes.  
+> Inside a function body, `$t` is not available — use the imperative `translate(...)` instead.
+
+If a component needs `$t` in the template **and** `translate()` in handlers, import both:
 
 ```svelte
 <script>
-	import { createNamespaceStore } from './translations/store';
-
-	const commonTranslations = createNamespaceStore('common');
-	const navigationTranslations = createNamespaceStore('navigation');
+	import { t } from '$lib/translations/store'; // for template
+	import { t as translate } from '$lib/translations'; // for handlers
 </script>
-
-<p>{$commonTranslations.loading}</p><p>{$navigationTranslations.allSurah}</p>
 ```
 
-### Direct Function Usage
+### With parameters
 
-```typescript
-import { t } from './translations/index';
+Use `{{variableName}}` in the JSON value and pass a params object:
 
-// In a function or component
-const loadingText = t('common.loading');
-const welcomeText = t('common.welcome', { name: 'User' });
+```svelte
+<p>{$t('common.welcome', { name: 'Ahmad' })}</p>
 ```
-
-## Adding New Languages
-
-1. Create a new JSON file (e.g., `ar.json` for Arabic)
-2. Add the language to `LANGUAGE_OPTIONS` in `checkLanguaguage.ts`
-3. Import and add the translation to the `translations` object in `index.ts`
-
-## Translation File Structure
-
-Each translation file should follow this structure:
 
 ```json
-{
-	"common": {
-		"loading": "Loading...",
-		"error": "An error occurred"
-	},
-	"navigation": {
-		"home": "Home",
-		"about": "About"
-	}
-}
+{ "common": { "welcome": "Welcome, {{name}}!" } }
 ```
 
-## String Interpolation
+### Namespace stores (bulk access)
 
-Use `{{variableName}}` syntax for parameters:
+```svelte
+<script>
+	import { createNamespaceStore } from '$lib/translations/store';
+	const common = createNamespaceStore('common');
+</script>
 
-```json
-{
-	"common": {
-		"welcome": "Welcome, {{name}}!"
-	}
-}
+<p>{$common.loading}</p>
 ```
 
-## Best Practices
+---
 
-1. Use nested objects to organize translations by feature
-2. Keep translation keys descriptive and consistent
-3. Always provide fallbacks for missing translations
-4. Use TypeScript for better type safety
-5. Test translations in all supported languages
+## Namespace conventions
 
-## Type Safety
+| Namespace          | Use for                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `common.*`         | Generic UI words reused across many pages (`close`, `back`, `save`, `unknownError`, `backToHome`, …) |
+| `navigation.*`     | Drawer/menu link labels (`home`, `allSurah`, `prayerTime`, `worshipTracker`, …)                      |
+| `surah.*`          | Quran reading page copy (`shareVerse`, `shareTranslation`, `listAllSurahs`, …)                       |
+| `settings.*`       | Settings page labels (`title`, `featureSettings`, `chooseQari`, …)                                   |
+| `aria.*`           | `aria-label` values on interactive controls (`toggleDrawer`, `switchTheme`, `changeLanguage`)        |
+| `pages.*`          | Standalone page titles that don't fit elsewhere (`termsOfService`, `privacyPolicy`)                  |
+| `worshipTracker.*` | Worship-tracker–specific copy                                                                        |
+| `prayerSchedule.*` | Prayer-schedule–specific copy                                                                        |
+| `sync.*`           | Sync-page toast messages                                                                             |
+| `ui.*`             | Miscellaneous UI strings not covered above                                                           |
 
-The translation system is fully typed. Translation keys are validated at compile time, and missing translations will fall back to Indonesian (the default language).
+**Reuse before adding.** Before creating a new key, search both JSON files for an existing string that fits. `navigation.home`, `common.close`, `settings.translation`, and `surah.share*` keys are commonly reusable.
+
+---
+
+## Adding or updating translation keys
+
+1. **Always edit both `id.json` and `en.json` at the same time.** A key present in one file but missing in the other will silently fall back to Indonesian, which is hard to notice during review.
+
+2. **Pick the right namespace.** See the table above. If the key belongs to an existing namespace, extend it. Only add a new top-level namespace when no existing one fits.
+
+3. **Use `camelCase` key names.** Examples: `featureSettings`, `noRecapData`, `locationSuccess`.
+
+4. **Interpolation syntax** is `{{variableName}}` (double curly braces):
+
+   ```json
+   { "sync": { "loginSuccess": "Welcome {{name}}!" } }
+   ```
+
+5. **Avoid duplicating strings across namespaces.** If a word like "Close" / "Tutup" already exists at `common.close`, reference that key — don't add `modal.close` with the same text.
+
+---
+
+## Replacing hardcoded locale ternaries
+
+The pattern below **bypasses the translation system** and should not be used:
+
+```svelte
+<!-- ❌ Do not do this -->
+{current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Settings' : 'Setelan'}
+```
+
+Replace it with:
+
+```svelte
+<!-- ✅ Do this -->
+{$t('settings.title')}
+```
+
+When removing a ternary, also check whether the surrounding `LANGUAGE_OPTIONS` / `languageStore` / `current` bindings are still needed elsewhere in the file. Remove them if they are now unused to avoid lint warnings.
+
+---
+
+## Adding new languages
+
+1. Create a new JSON file (e.g., `ar.json` for Arabic).
+2. Add the locale to `LANGUAGE_OPTIONS` in `checkLanguaguage.ts`.
+3. Import and register it in `translations` object in `index.ts`.
+
+---
+
+## Verification checklist
+
+Run these checks after any translation change before opening a PR:
+
+### 1. Both JSON files updated
+
+```bash
+# Confirm the key exists in both files
+grep -n "yourNewKey" src/lib/translations/id.json src/lib/translations/en.json
+```
+
+### 2. No hardcoded locale ternaries remain
+
+```bash
+# Should return no output in the files you changed
+grep -rn "LANGUAGE_OPTIONS.ENGLISH.locale ?" src/routes/ src/lib/
+```
+
+### 3. No unused imports
+
+```bash
+# Check files you modified for leftover LANGUAGE_OPTIONS / languageStore / current
+grep -n "LANGUAGE_OPTIONS\|languageStore\|current ==" src/routes/YOUR_FILE.svelte
+```
+
+### 4. Prettier formatting
+
+```bash
+pnpm lint
+# or directly:
+./node_modules/.bin/prettier --check "src/**/*.svelte" "src/**/*.json"
+```
+
+### 5. Type check
+
+```bash
+pnpm check
+```
+
+### 6. Manual smoke test
+
+Switch the language using the globe icon and confirm:
+
+- All changed strings update without a page reload.
+- Toast messages (if any) appear in the selected language on next trigger.
+
+---
+
+## Type safety
+
+Translation keys are validated at compile time. Missing keys fall back to Indonesian (the default language). Run `pnpm check` to catch missing or mis-typed keys early.

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -118,6 +118,11 @@
 		"prevMonth": "Previous month",
 		"nextMonth": "Next month"
 	},
+	"aria": {
+		"toggleDrawer": "Toggle Drawer",
+		"switchTheme": "Switch Theme",
+		"changeLanguage": "Change Language"
+	},
 	"daily-doa": {
 		"filterAll": "All",
 		"source": "Source",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -16,7 +16,9 @@
 		"home": "Home",
 		"about": "About",
 		"settings": "Settings",
-		"welcome": "Welcome, {{name}}!"
+		"welcome": "Welcome, {{name}}!",
+		"backToHome": "Back to Home",
+		"unknownError": "Unknown error"
 	},
 	"navigation": {
 		"allSurah": "All Surahs",
@@ -66,7 +68,8 @@
 		"noPinnedSurahs": "You don't have any pinned surahs!",
 		"startPinningSurahs": "Start pinning up to 6 surahs for quick access.",
 		"noBookmarkedVerses": "You don't have any bookmarked verses!",
-		"startReadingVerses": "Start reading and bookmark verses."
+		"startReadingVerses": "Start reading and bookmark verses.",
+		"listAllSurahs": "List of All Surahs"
 	},
 	"prayer": {
 		"fajr": "Fajr",
@@ -84,7 +87,14 @@
 		"translation": "Translation",
 		"tafsir": "Tafsir",
 		"autoNext": "Auto Next",
-		"fontSize": "Font Size"
+		"fontSize": "Font Size",
+		"title": "Settings",
+		"featureSettings": "Feature Settings",
+		"alwaysShowTranslation": "Always show translation",
+		"showTafsirButton": "Show tafsir button",
+		"audioSettings": "Audio Settings",
+		"autoPlayNextVerse": "Automatically play next verse",
+		"chooseQari": "Choose Qari"
 	},
 	"ui": {
 		"by": "by",
@@ -117,6 +127,22 @@
 		"today": "Today",
 		"prevMonth": "Previous month",
 		"nextMonth": "Next month"
+	},
+	"pages": {
+		"termsOfService": "Terms of Service",
+		"privacyPolicy": "Privacy Policy"
+	},
+	"worshipTracker": {
+		"viewRecap": "View Recap",
+		"logRecap": "Prayer Log Recap",
+		"date": "Date",
+		"noRecapData": "No recap data for {{month}} yet"
+	},
+	"prayerSchedule": {
+		"locationSuccess": "Managed to get the latest location!",
+		"updateLocation": "Update Location",
+		"allowLocation": "Allow location access",
+		"locationUnknown": "Location not set"
 	},
 	"sync": {
 		"loginSuccess": "Login successful. Welcome {{name}}!",

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -118,6 +118,16 @@
 		"prevMonth": "Previous month",
 		"nextMonth": "Next month"
 	},
+	"sync": {
+		"loginSuccess": "Login successful. Welcome {{name}}!",
+		"loginError": "Login failed: {{message}}",
+		"logoutSuccess": "Logout successful!",
+		"logoutError": "Logout failed: {{message}}",
+		"uploadSuccess": "Local data successfully synced to remote",
+		"uploadError": "Failed to sync local data to remote",
+		"downloadSuccess": "Local data updated successfully!",
+		"downloadEmpty": "You don't have any remote data yet. Local data will not be updated!"
+	},
 	"aria": {
 		"toggleDrawer": "Toggle Drawer",
 		"switchTheme": "Switch Theme",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -16,7 +16,9 @@
 		"home": "Beranda",
 		"about": "Tentang",
 		"settings": "Pengaturan",
-		"welcome": "Selamat datang, {{name}}!"
+		"welcome": "Selamat datang, {{name}}!",
+		"backToHome": "Kembali ke Beranda",
+		"unknownError": "tidak diketahui"
 	},
 	"navigation": {
 		"allSurah": "Semua Surat",
@@ -66,7 +68,8 @@
 		"noPinnedSurahs": "Kamu belum punya surah yang di pin!",
 		"startPinningSurahs": "Mulai pin 6 surah agar mudah diakses.",
 		"noBookmarkedVerses": "Kamu belum punya ayat yang ditandai!",
-		"startReadingVerses": "Yuk mulai baca dan tandai ayat."
+		"startReadingVerses": "Yuk mulai baca dan tandai ayat.",
+		"listAllSurahs": "Daftar Semua Surat"
 	},
 	"prayer": {
 		"fajr": "Subuh",
@@ -84,7 +87,14 @@
 		"translation": "Terjemahan",
 		"tafsir": "Tafsir",
 		"autoNext": "Otomatis Lanjut",
-		"fontSize": "Ukuran Font"
+		"fontSize": "Ukuran Font",
+		"title": "Setelan",
+		"featureSettings": "Setelan Fitur",
+		"alwaysShowTranslation": "Selalu tampilkan terjemahan",
+		"showTafsirButton": "Tampilkan tombol tafsir",
+		"audioSettings": "Setelan Audio",
+		"autoPlayNextVerse": "Otomatis putar ayat berikutnya",
+		"chooseQari": "Pilih Qari"
 	},
 	"ui": {
 		"by": "oleh",
@@ -117,6 +127,22 @@
 		"today": "Hari Ini",
 		"prevMonth": "Bulan sebelumnya",
 		"nextMonth": "Bulan berikutnya"
+	},
+	"pages": {
+		"termsOfService": "Ketentuan Layanan",
+		"privacyPolicy": "Kebijakan Privasi"
+	},
+	"worshipTracker": {
+		"viewRecap": "Lihat Rekap",
+		"logRecap": "Rekap Pencatat Ibadah",
+		"date": "Tanggal",
+		"noRecapData": "Belum ada data rekap untuk bulan {{month}}"
+	},
+	"prayerSchedule": {
+		"locationSuccess": "Berhasil mendapatkan lokasi teranyar!",
+		"updateLocation": "Perbarui Lokasi",
+		"allowLocation": "Beri akses lokasi",
+		"locationUnknown": "Lokasi belum diketahui"
 	},
 	"sync": {
 		"loginSuccess": "Berhasil login. Selamat datang {{name}}!",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -118,6 +118,16 @@
 		"prevMonth": "Bulan sebelumnya",
 		"nextMonth": "Bulan berikutnya"
 	},
+	"sync": {
+		"loginSuccess": "Berhasil login. Selamat datang {{name}}!",
+		"loginError": "Gagal login: {{message}}",
+		"logoutSuccess": "Berhasil logout!",
+		"logoutError": "Gagal logout: {{message}}",
+		"uploadSuccess": "Berhasil menyinkronkan data lokal ke remote",
+		"uploadError": "Gagal menyinkronkan data lokal ke remote",
+		"downloadSuccess": "Data di lokal berhasil diperbarui!",
+		"downloadEmpty": "Kamu belum memiliki data apapun di remote. Data di lokal tidak akan diperbarui!"
+	},
 	"aria": {
 		"toggleDrawer": "Buka/Tutup Menu",
 		"switchTheme": "Ganti Tema",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -118,6 +118,11 @@
 		"prevMonth": "Bulan sebelumnya",
 		"nextMonth": "Bulan berikutnya"
 	},
+	"aria": {
+		"toggleDrawer": "Buka/Tutup Menu",
+		"switchTheme": "Ganti Tema",
+		"changeLanguage": "Ganti Bahasa"
+	},
 	"daily-doa": {
 		"filterAll": "Semua",
 		"source": "Sumber",

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,9 +1,8 @@
 <script>
 	import { page } from '$app/stores';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import ArrowLeftIcon from '$lib/icons/ArrowLeftIcon.svelte';
 	import Button from '$lib/ui/Button.svelte';
-	const current = $derived(languageStore);
+	import { t } from '$lib/translations/store';
 </script>
 
 <div class="m-6 flex flex-col gap-2 justify-center items-center">
@@ -11,9 +10,7 @@
 	<p class="mt-2 text-red-600 bg-red-50 p-2 rounded-lg">
 		<span class="font-bold">Error Message: </span>
 		<span>
-			{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-				? $page?.error?.message || 'Unknown error'
-				: $page?.error?.message || 'tidak diketahui'}
+			{$page?.error?.message || $t('common.unknownError')}
 		</span>
 	</p>
 	<img
@@ -27,6 +24,6 @@
 		}}
 	>
 		<ArrowLeftIcon />
-		{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Back to Home' : 'Kembali ke Beranda'}
+		{$t('common.backToHome')}
 	</Button>
 </div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -19,11 +19,7 @@
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb
-		items={[
-			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
-		]}
-	/>
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
 {#if current == LANGUAGE_OPTIONS.ENGLISH.locale}
 	<article class="px-4">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,7 +3,8 @@
 	import MetaTag from '$lib/MetaTag.svelte';
 	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { META_DESC, META_TITLE, TITLE_CONSTANTS } from '$lib/constants';
-	$: current = $languageStore;
+	import { t } from '$lib/translations/store';
+	const current = $derived(languageStore);
 </script>
 
 <svelte:head>
@@ -13,18 +14,14 @@
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
 		ℹ️
-		{#if current == LANGUAGE_OPTIONS.ENGLISH.locale}
-			About
-		{:else}
-			Tentang
-		{/if}
+		{$t('common.about')}
 	</h1>
 </div>
 
 <div class="px-4 mb-4">
 	<Breadcrumb
 		items={[
-			{ text: `🏠${current == LANGUAGE_OPTIONS.ENGLISH.locale ? ' Home' : 'Beranda'}`, href: '/' }
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
 		]}
 	/>
 </div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -21,7 +21,7 @@
 <div class="px-4 mb-4">
 	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
-{#if current == LANGUAGE_OPTIONS.ENGLISH.locale}
+{#if $current == LANGUAGE_OPTIONS.ENGLISH.locale}
 	<article class="px-4">
 		<p class="mb-4">
 			Baca-Quran.id is a web application for reading the Quran through a browser, without the need

--- a/src/routes/all-surah/+page.svelte
+++ b/src/routes/all-surah/+page.svelte
@@ -6,9 +6,7 @@
 	import MakkiyahMadaniyah from '../../data/makkiyah-madaniyah';
 	import SurahList from '$lib/SurahList.svelte';
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
-	const current = $derived(languageStore);
 
 	function insertMakkiyahMadaniyah() {
 		let result: SurahInfo = {};
@@ -36,7 +34,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		📚 {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'List of All Surahs' : 'Daftar Semua Surat'}
+		📚 {$t('surah.listAllSurahs')}
 	</h1>
 </div>
 

--- a/src/routes/asmaul-husna/+page.svelte
+++ b/src/routes/asmaul-husna/+page.svelte
@@ -22,11 +22,7 @@
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb
-		items={[
-			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
-		]}
-	/>
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
 
 <div class="px-4 flex flex-col gap-2">

--- a/src/routes/asmaul-husna/+page.svelte
+++ b/src/routes/asmaul-husna/+page.svelte
@@ -3,11 +3,10 @@
 	import CardShadow from '$lib/CardShadow.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { META_DESC_ASMAUL_HUSNA, META_TITLE_ASMAUL_HUSNA, TITLE_CONSTANTS } from '$lib/constants';
 	import Badge from '$lib/ui/Badge.svelte';
 	import asmaulHusna from '../../data/asmaul-husna';
-	$: current = $languageStore;
+	import { t } from '$lib/translations/store';
 </script>
 
 <svelte:head>
@@ -25,7 +24,7 @@
 <div class="px-4 mb-4">
 	<Breadcrumb
 		items={[
-			{ text: `🏠${current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Home' : 'Beranda'}`, href: '/' }
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
 		]}
 	/>
 </div>

--- a/src/routes/ayat-kursi/+page.svelte
+++ b/src/routes/ayat-kursi/+page.svelte
@@ -33,11 +33,7 @@
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb
-		items={[
-			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
-		]}
-	/>
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
 
 <div class="px-4 flex flex-col gap-2">
@@ -48,10 +44,7 @@
 		</div>
 		<div class="mt-4 flex justify-between items-center gap-2">
 			<div class="flex items-center gap-2">
-				<Button
-					onClick={toggleBottomSheet}
-					ariaLabel={$t('settings.translation')}
-				>
+				<Button onClick={toggleBottomSheet} ariaLabel={$t('settings.translation')}>
 					<DocumentTextIcon />
 				</Button>
 			</div>

--- a/src/routes/ayat-kursi/+page.svelte
+++ b/src/routes/ayat-kursi/+page.svelte
@@ -3,18 +3,18 @@
 	import CardShadow from '$lib/CardShadow.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { META_DESC_AYAT_KURSI, META_TITLE_AYAT_KURSI, TITLE_CONSTANTS } from '$lib/constants';
 	import DocumentTextIcon from '$lib/icons/DocumentTextIcon.svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import ayatKursi from '../../data/ayat-kursi';
 	import { globalBottomSheet } from '../../store/globalBottomSheet';
-	$: current = $languageStore;
+	import { t as translate } from '$lib/translations';
+	import { t } from '$lib/translations/store';
 
 	let toggleBottomSheet = () => {
 		globalBottomSheet.toggle({
-			title: `💠${current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Translation' : 'Terjemahan'} Ayat Kursi`,
-			content: `<p class="mb-4">🔸 <b>${current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Translation' : 'Terjemahan'}</b>: ${ayatKursi.translation}</p>
+			title: `💠 ${translate('settings.translation')} Ayat Kursi`,
+			content: `<p class="mb-4">🔸 <b>${translate('settings.translation')}</b>: ${ayatKursi.translation}</p>
         <p>🔹 <b>Tafsir</b>: ${ayatKursi.tafsir}</p>`
 		});
 	};
@@ -35,7 +35,7 @@
 <div class="px-4 mb-4">
 	<Breadcrumb
 		items={[
-			{ text: `🏠${current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Home' : 'Beranda'}`, href: '/' }
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
 		]}
 	/>
 </div>
@@ -50,8 +50,7 @@
 			<div class="flex items-center gap-2">
 				<Button
 					onClick={toggleBottomSheet}
-					ariaLabel={'Baca ' +
-						(current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Translation' : 'Terjemahan')}
+					ariaLabel={$t('settings.translation')}
 				>
 					<DocumentTextIcon />
 				</Button>

--- a/src/routes/jadwal-sholat/+page.svelte
+++ b/src/routes/jadwal-sholat/+page.svelte
@@ -17,12 +17,11 @@
 	import Clock from '$lib/Clock.svelte';
 	import { toast } from '../../store/toast';
 	import PrayerTimeList from '$lib/PrayerTimeList.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
+	import { t as translate } from '$lib/translations';
 
 	const BASE_URL = 'https://api.aladhan.com/v1/calendar';
 	let prayerTimes: PrayerTimeData[] = $state([]);
-	const current = $derived(languageStore);
 	let todayPrayerTime = $derived(
 		prayerTimes.find((time) => {
 			return (
@@ -125,7 +124,7 @@
 				);
 
 				toast.show({
-					message: `${$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Managed to get the latest location!' : 'Berhasil mendapatkan lokasi teranyar!'}`,
+					message: translate('prayerSchedule.locationSuccess'),
 					type: 'success'
 				});
 
@@ -161,7 +160,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		⏰ {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Prayer schedule' : 'Jadwal Sholat'}
+		⏰ {$t('navigation.prayerTime')}
 	</h1>
 </div>
 
@@ -180,13 +179,11 @@
 	{#if $settingLocation === null}
 		<div class="flex flex-wrap gap-2 justify-between items-center">
 			<h2 class="text-xl font-bold">
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? '' : 'Lokasi belum diketahui'}
+				{$t('prayerSchedule.locationUnknown')}
 			</h2>
 			<div>
 				<Button onClick={getGeolocation}>
-					<MarkerIcon />{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-						? 'Allow location access'
-						: 'Beri akses lokasi'}
+					<MarkerIcon />{$t('prayerSchedule.allowLocation')}
 				</Button>
 			</div>
 		</div>
@@ -203,7 +200,7 @@
 
 			<Button onClick={getGeolocation}>
 				<MarkerIcon />
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Update Location' : 'Perbarui Lokasi'}
+				{$t('prayerSchedule.updateLocation')}
 			</Button>
 		</div>
 	{/if}

--- a/src/routes/juz-amma/+page.svelte
+++ b/src/routes/juz-amma/+page.svelte
@@ -41,11 +41,7 @@
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb
-		items={[
-			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
-		]}
-	/>
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
 
 <SurahList {originSurahInfo} />

--- a/src/routes/juz-amma/+page.svelte
+++ b/src/routes/juz-amma/+page.svelte
@@ -3,13 +3,12 @@
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
 	import SurahList from '$lib/SurahList.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { META_DESC_JUZ_AMMA, META_TITLE_JUZ_AMMA, TITLE_CONSTANTS } from '$lib/constants';
+	import { t } from '$lib/translations/store';
 	import MakkiyahMadaniyah from '../../data/makkiyah-madaniyah';
 	import surahInfo, { type SurahInfo } from '../../data/surah-info';
 
 	const SURAH_START = 78;
-	const current = $derived(languageStore);
 
 	function insertMakkiyahMadaniyah() {
 		let result: SurahInfo = {};
@@ -44,7 +43,7 @@
 <div class="px-4 mb-4">
 	<Breadcrumb
 		items={[
-			{ text: `🏠${$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Home' : 'Beranda'}`, href: '/' }
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' }
 		]}
 	/>
 </div>

--- a/src/routes/kebijakan-privasi/+page.svelte
+++ b/src/routes/kebijakan-privasi/+page.svelte
@@ -16,7 +16,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? '🤝 Privacy Policy' : '🤝 Kebijakan Privasi'}
+		🤝 {$t('pages.privacyPolicy')}
 	</h1>
 </div>
 

--- a/src/routes/ketentuan-layanan/+page.svelte
+++ b/src/routes/ketentuan-layanan/+page.svelte
@@ -16,7 +16,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		🤝 {$current === LANGUAGE_OPTIONS.ENGLISH.locale ? 'Terms of Service' : 'Ketentuan Layanan'}
+		🤝 {$t('pages.termsOfService')}
 	</h1>
 </div>
 

--- a/src/routes/pencatat-ibadah/+page.svelte
+++ b/src/routes/pencatat-ibadah/+page.svelte
@@ -21,9 +21,7 @@
 	import { onMount } from 'svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
-	const current = $derived(languageStore);
 
 	let defaultItem = {
 		'1': 0,
@@ -146,7 +144,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		{$current === LANGUAGE_OPTIONS.ENGLISH.locale ? '⏺️ Worship Tracker' : '⏺️ Pencatat Ibadah'}
+		⏺️ {$t('navigation.worshipTracker')}
 	</h1>
 </div>
 
@@ -166,7 +164,7 @@
 		<p class="text-lg">{selectedDateFormatted}</p>
 		<a href="/pencatat-ibadah/rekap/">
 			<Button onClick={() => {}} class="text-sm justify-center items-center">
-				{$current === LANGUAGE_OPTIONS.ENGLISH.locale ? 'View Recap' : 'Lihat Rekap'}
+				{$t('worshipTracker.viewRecap')}
 				<ArrowRightIcon size="sm" />
 			</Button>
 		</a>

--- a/src/routes/pencatat-ibadah/rekap/+page.svelte
+++ b/src/routes/pencatat-ibadah/rekap/+page.svelte
@@ -2,7 +2,6 @@
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
 	import {
 		META_DESC_PENCATAT_IBADAH,
@@ -11,7 +10,6 @@
 	} from '$lib/constants';
 	import { formatDate, getAllMonths } from '$lib/utils/date';
 	import { logPrayer } from '$store';
-	const current = $derived(languageStore);
 
 	let monthRanges = getAllMonths();
 
@@ -41,7 +39,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		⏺️ {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Prayer Log Recap' : 'Rekap Pencatat Ibadah'}
+		⏺️ {$t('worshipTracker.logRecap')}
 	</h1>
 </div>
 
@@ -50,7 +48,7 @@
 		items={[
 			{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
 			{
-				text: $current == LANGUAGE_OPTIONS.ENGLISH.locale ? '⏺️ Prayer Log' : '⏺️ Pencatat Ibadah',
+				text: `⏺️ ${$t('navigation.worshipTracker')}`,
 				href: '/pencatat-ibadah/'
 			}
 		]}
@@ -81,7 +79,7 @@
 				<thead>
 					<tr>
 						<th scope="col">
-							{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Date' : 'Tanggal'}
+							{$t('worshipTracker.date')}
 						</th>
 						<th scope="col">Subuh</th>
 						<th scope="col">Dzuhur</th>
@@ -104,9 +102,7 @@
 		{:else}
 			<div class="m-6 flex flex-col gap-2 justify-center items-center p-4">
 				<p class="text-2xl text-center font-bold">
-					{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-						? `No recap data for ${selectedMonth} yet`
-						: `Belum ada data rekap untuk bulan ${selectedMonth}`}
+					{$t('worshipTracker.noRecapData', { month: selectedMonth })}
 				</p>
 				<img
 					src="/images/illustrasion-error.svg"

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,7 +7,6 @@
 	import { CONSTANTS, META_DESC, META_TITLE, TITLE_CONSTANTS } from '$lib/constants';
 	import surahData from '../../data/surah-data/108';
 	import { settingAudio, settingAutoNext, settingTafsir, settingTranslation } from '../../store';
-	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
 
 	type SurahSampleEntry = {
@@ -23,7 +22,6 @@
 	const sample = (surahData as unknown as Record<string, SurahSampleEntry>)[
 		SURAH_SAMPLE.toString()
 	];
-	const current = $derived(languageStore);
 </script>
 
 <svelte:head>
@@ -32,7 +30,7 @@
 
 <div class="flex gap-2 px-4 mb-4">
 	<h1 class="text-3xl font-bold">
-		⚙️ {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Settings' : 'Setelan'}
+		⚙️ {$t('settings.title')}
 	</h1>
 </div>
 
@@ -43,7 +41,7 @@
 <article class="px-4 flex flex-col gap-4 divide-y">
 	<div class="flex flex-col gap-2">
 		<h3 class="text-xl font-bold">
-			💠 {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Feature Settings' : 'Setelan Fitur'}
+			💠 {$t('settings.featureSettings')}
 		</h3>
 		<div>
 			<input
@@ -61,9 +59,7 @@
 				}}
 			/>
 			<label for="chk-translation">
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-					? 'Always show translation'
-					: 'Selalu tampilkan terjemahan'}
+				{$t('settings.alwaysShowTranslation')}
 			</label>
 		</div>
 		<div>
@@ -82,9 +78,7 @@
 				}}
 			/>
 			<label for="chk-tafsir">
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-					? 'Show tafsir button'
-					: 'Tampilkan tombol tafsir'}
+				{$t('settings.showTafsirButton')}
 			</label>
 		</div>
 		<!-- <div>
@@ -126,7 +120,7 @@
 
 	<div class="pt-4 flex flex-col gap-2">
 		<h3 class="text-xl font-bold">
-			🔈 {$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Audio Settings' : 'Setelan Audio'}
+			🔈 {$t('settings.audioSettings')}
 		</h3>
 		<div>
 			<input
@@ -144,15 +138,13 @@
 				}}
 			/>
 			<label for="chk-auto-next">
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale
-					? 'Automatically play next verse'
-					: 'Otomatis putar ayat berikutnya'}
+				{$t('settings.autoPlayNextVerse')}
 			</label>
 		</div>
 
 		<div>
 			<label for="select-qari" class="block mb-2 text-sm font-medium">
-				{$current == LANGUAGE_OPTIONS.ENGLISH.locale ? 'Choose Qari' : 'Pilih Qari'}
+				{$t('settings.chooseQari')}
 			</label>
 			<div class="flex items-center gap-2">
 				<select

--- a/src/routes/sync/+page.svelte
+++ b/src/routes/sync/+page.svelte
@@ -15,6 +15,7 @@
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import { t } from '$lib/translations/store';
+	import { t as translate } from '$lib/translations';
 	import { initializeApp } from 'firebase/app';
 	import {
 		getFirestore,
@@ -84,13 +85,13 @@
 			.then((result) => {
 				const user = result.user;
 				toast.show({
-					message: `Berhasil login. Selamat datang ${user.displayName}!`,
+					message: translate('sync.loginSuccess', { name: user.displayName || '' }),
 					type: 'success'
 				});
 			})
 			.catch((error) => {
 				toast.show({
-					message: `Gagal login: ${error.message}`,
+					message: translate('sync.loginError', { message: error.message }),
 					type: 'error'
 				});
 			});
@@ -100,13 +101,13 @@
 		signOut(auth)
 			.then(() => {
 				toast.show({
-					message: `Berhasil logout!`,
+					message: translate('sync.logoutSuccess'),
 					type: 'success'
 				});
 			})
 			.catch((error) => {
 				toast.show({
-					message: `Gagal logout: ${error.message}`,
+					message: translate('sync.logoutError', { message: error.message }),
 					type: 'error'
 				});
 			});
@@ -167,14 +168,14 @@
 				});
 
 				toast.show({
-					message: `Berhasil memperbarui data remote dengan data lokal`,
+					message: translate('sync.uploadSuccess'),
 					type: 'success'
 				});
 			} catch (e) {
 				console.error('Error updating document: ', localData, e);
 
 				toast.show({
-					message: `Gagal memperbarui data lokal ke remote`,
+					message: translate('sync.uploadError'),
 					type: 'error'
 				});
 			}
@@ -183,14 +184,14 @@
 				await addDoc(collection(db, 'progress'), localData);
 
 				toast.show({
-					message: `Berhasil mengunggah data lokal ke remote`,
+					message: translate('sync.uploadSuccess'),
 					type: 'success'
 				});
 			} catch (e) {
 				console.error('Error adding new document: ', localData, e);
 
 				toast.show({
-					message: `Gagal mengunggah data lokal ke remote`,
+					message: translate('sync.uploadError'),
 					type: 'error'
 				});
 			}
@@ -285,12 +286,12 @@
 			});
 
 			toast.show({
-				message: `Data di lokal berhasil diperbarui!`,
+				message: translate('sync.downloadSuccess'),
 				type: 'success'
 			});
 		} else {
 			toast.show({
-				message: `Kamu belum memiliki data apapun di remote. Data di lokal tidak akan diperbarui!`,
+				message: translate('sync.downloadEmpty'),
 				type: 'error'
 			});
 		}


### PR DESCRIPTION
Replaces hardcoded aria-label values in Header, ThemeSwicther,
LanguageChanger, and Toaster with reactive $t() calls. Adds a new
aria.* namespace to id.json and en.json; Toaster reuses common.close.

Closes #427