### PR TITLE
feat: add /design-system documentation page + redesign Badge/Button

### DIFF
--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -4,6 +4,7 @@ export const staticUrls = [
 	'/asmaul-husna',
 	'/ayat-kursi',
 	'/daily-doa',
+	'/design-system',
 	'/jadwal-sholat',
 	'/juz-amma',
 	'/kalender-hijriyah',

--- a/src/lib/DrawerMenus.svelte
+++ b/src/lib/DrawerMenus.svelte
@@ -5,6 +5,7 @@
 	import InformationCircleIcon from './icons/InformationCircleIcon.svelte';
 	import ResetIcon from './icons/ResetIcon.svelte';
 	import SettingIcon from './icons/SettingIcon.svelte';
+	import SwatchIcon from './icons/SwatchIcon.svelte';
 </script>
 
 <ul class="mt-2 flex flex-col gap-2">
@@ -47,6 +48,16 @@
 		>
 			<HashtagIcon />
 			{$t('navigation.ayatOfTheDay')}
+		</a>
+	</li>
+	<li class="sidebar__item">
+		<a
+			data-sveltekit-reload
+			href="/design-system/"
+			class="flex gap-2 items-center p-2 rounded-md hover:bg-primary focus:bg-primary"
+		>
+			<SwatchIcon />
+			{$t('navigation.designSystem')}
 		</a>
 	</li>
 	<li class="sidebar__item">

--- a/src/lib/SurahCard.svelte
+++ b/src/lib/SurahCard.svelte
@@ -100,7 +100,7 @@
 					class="z-10"
 					href={`/surah-${surah?.revelation === MADANIYAH_CODE ? 'madaniyah' : 'makkiyah'}/`}
 				>
-					<Badge color={surah?.revelation === MADANIYAH_CODE ? 'green' : 'orange'}>
+					<Badge color={surah?.revelation === MADANIYAH_CODE ? 'success' : 'warning'}>
 						{MAKKIYAH_MADANIYAH_TEXT[
 							surah?.revelation?.toString() as keyof typeof MAKKIYAH_MADANIYAH_TEXT
 						]}

--- a/src/lib/icons/SwatchIcon.svelte
+++ b/src/lib/icons/SwatchIcon.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { CLASS_BY_SIZE, type IconSize } from './utils';
+
+	interface Props {
+		size?: IconSize;
+		class?: string;
+	}
+
+	let { size = 'md', class: clazz }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width="1.5"
+	stroke="currentColor"
+	class={clazz || CLASS_BY_SIZE[size]}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z"
+	/>
+</svg>

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -39,7 +39,8 @@
 		"sync": "Sync",
 		"about": "About",
 		"ayatOfTheDay": "AyatOfTheDay",
-		"hijriCalendar": "Hijri Calendar"
+		"hijriCalendar": "Hijri Calendar",
+		"designSystem": "Design System"
 	},
 	"surah": {
 		"title": "Read Quran",
@@ -176,6 +177,116 @@
 			"perlindungan": "Protection",
 			"sholat": "Prayer",
 			"umum": "General"
+		}
+	},
+	"designSystem": {
+		"toc": {
+			"title": "Table of Contents"
+		},
+		"section": {
+			"colors": "Colors & Tokens",
+			"colorsDesc": "Core color tokens used for backgrounds, text, and borders across every theme.",
+			"themes": "Themes",
+			"typography": "Typography",
+			"typographyDesc": "Standard text-size scale plus the dedicated Arabic font used for Quranic verses.",
+			"buttons": "Buttons",
+			"buttonsDesc": "Primary, secondary, and outline actions. Supports icons, labels, or both.",
+			"badges": "Badges",
+			"badgesDesc": "Tiny status markers — for example Makkiyah vs Madaniyah surah type.",
+			"chips": "Chips / Pills",
+			"chipsDesc": "Compact labels or selectable filters. Supports color variants and active state.",
+			"banners": "Banner / Alert",
+			"bannersDesc": "Inline messages used to surface status or warnings. Unlike toasts, banners stay in place.",
+			"forms": "Form Controls",
+			"formsDesc": "Inputs, textarea, checkbox and radio with consistent labels and error messaging.",
+			"collapsible": "Collapsible",
+			"collapsibleDesc": "Expandable container for progressively-disclosed content.",
+			"bottomSheet": "Bottom Sheet",
+			"bottomSheetDesc": "Panel that slides up from the bottom edge for contextual actions or details.",
+			"toasts": "Toasts",
+			"toastsDesc": "Short notifications shown at the top. Supports info, success, warn, and error.",
+			"breadcrumb": "Breadcrumb",
+			"breadcrumbDesc": "Hierarchical navigation trail to the current page.",
+			"cards": "Cards",
+			"cardsDesc": "Content containers with secondary background and soft shadow.",
+			"icons": "Icons",
+			"iconsDesc": "Shared SVG icon set. Every icon accepts a size prop."
+		},
+		"colors": {
+			"semanticTokens": "Semantic Tokens",
+			"themePalette": "Per-theme Palette",
+			"themePaletteDesc": "Each theme has its own background and accent color. Switch themes from the header icon.",
+			"utilityPalette": "Utility Palette",
+			"utilityPaletteDesc": "Tailwind utility ramps used for status colors (info, success, warn, error)."
+		},
+		"buttons": {
+			"filled": "Filled",
+			"subtle": "Subtle",
+			"outline": "Outline",
+			"withIcon": "With Icon"
+		},
+		"chips": {
+			"interactive": "Interactive chips — use as filters."
+		},
+		"banner": {
+			"infoTitle": "Information",
+			"infoBody": "Info banners are used for neutral messages or light guidance.",
+			"successTitle": "Success",
+			"successBody": "Action completed successfully and your data has been saved.",
+			"warnTitle": "Warning",
+			"warnBody": "Double-check your input before continuing.",
+			"errorTitle": "Error",
+			"errorBody": "Something went wrong. Please try again in a moment.",
+			"dismissibleBody": "This banner can be dismissed. Click the X on the right to close it.",
+			"dismissedHint": "Banner has been dismissed.",
+			"restore": "Restore"
+		},
+		"forms": {
+			"textLabel": "Name",
+			"textPlaceholder": "Type your name",
+			"textHint": "Only stored in your browser.",
+			"emailLabel": "Email",
+			"emailError": "Invalid email format.",
+			"disabledLabel": "Disabled field",
+			"textareaLabel": "Notes",
+			"textareaPlaceholder": "Write your notes here",
+			"textareaHint": "A few paragraphs at most.",
+			"checkboxA": "Receive notifications",
+			"checkboxAHint": "Only important notifications.",
+			"checkboxB": "Enable verse auto-next",
+			"checkboxDisabled": "This option is currently disabled",
+			"radioId": "Bahasa Indonesia",
+			"radioEn": "English",
+			"radioAr": "العربية",
+			"radioArHint": "Available only on some pages.",
+			"selected": "Selected:"
+		},
+		"collapsible": {
+			"what": "What is a collapsible?",
+			"when": "When to use it?"
+		},
+		"bottomSheet": {
+			"open": "Open Bottom Sheet",
+			"demoTitle": "Bottom Sheet Demo"
+		},
+		"cards": {
+			"variants": "Variants",
+			"filledDesc": "Secondary background, no shadow.",
+			"outlineDesc": "Thin border, primary background.",
+			"elevatedDesc": "Secondary background with shadow.",
+			"composed": "With Header & Footer",
+			"withHeaderTitle": "Favorite Surah",
+			"withHeaderBody": "Pin a surah so it's easy to reach from the home page.",
+			"linkTitle": "Learn more",
+			"linkSubtitle": "Open design-system detail",
+			"linkBody": "A clickable card — rendered as an anchor.",
+			"padding": "Padding",
+			"legacy": "Legacy component",
+			"legacyDesc": "CardShadow is still used across many pages and stays compatible with existing layouts."
+		},
+		"icons": {
+			"sizes": "Sizes",
+			"gallery": "Icon Gallery"
 		}
 	}
 }

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -190,9 +190,11 @@
 			"typography": "Typography",
 			"typographyDesc": "Standard text-size scale plus the dedicated Arabic font used for Quranic verses.",
 			"buttons": "Buttons",
-			"buttonsDesc": "Primary, secondary, and outline actions. Supports icons, labels, or both.",
+			"buttonsDesc": "Variant × color matrix. Use solid for the primary action, subtle for secondary actions, outline for the lowest emphasis.",
+			"iconButtons": "Icon Buttons",
+			"iconButtonsDesc": "Fixed-size square buttons for compact actions without a label. ariaLabel is required.",
 			"badges": "Badges",
-			"badgesDesc": "Tiny status markers — for example Makkiyah vs Madaniyah surah type.",
+			"badgesDesc": "Tiny status markers. Same variant × color matrix as buttons.",
 			"chips": "Chips / Pills",
 			"chipsDesc": "Compact labels or selectable filters. Supports color variants and active state.",
 			"banners": "Banner / Alert",
@@ -220,9 +222,19 @@
 			"utilityPaletteDesc": "Tailwind utility ramps used for status colors (info, success, warn, error)."
 		},
 		"buttons": {
-			"filled": "Filled",
-			"subtle": "Subtle",
-			"outline": "Outline",
+			"matrix": "Variant × Color",
+			"matrixDesc": "Pair any variant with any color to match the action's intent.",
+			"withIcon": "With Icon",
+			"disabled": "Disabled"
+		},
+		"iconButtons": {
+			"sizes": "Sizes",
+			"variants": "Variants & Colors",
+			"rounded": "Corners",
+			"disabled": "Disabled"
+		},
+		"badges": {
+			"matrix": "Variant × Color",
 			"withIcon": "With Icon"
 		},
 		"chips": {

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -224,6 +224,7 @@
 		"buttons": {
 			"matrix": "Variant × Color",
 			"matrixDesc": "Pair any variant with any color to match the action's intent.",
+			"sizes": "Sizes",
 			"withIcon": "With Icon",
 			"disabled": "Disabled"
 		},
@@ -235,6 +236,7 @@
 		},
 		"badges": {
 			"matrix": "Variant × Color",
+			"sizes": "Sizes",
 			"withIcon": "With Icon"
 		},
 		"chips": {
@@ -271,7 +273,8 @@
 			"radioEn": "English",
 			"radioAr": "العربية",
 			"radioArHint": "Available only on some pages.",
-			"selected": "Selected:"
+			"selected": "Selected:",
+			"sizes": "Sizes"
 		},
 		"collapsible": {
 			"what": "What is a collapsible?",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -190,9 +190,11 @@
 			"typography": "Tipografi",
 			"typographyDesc": "Skala ukuran teks standar serta font Arab khusus untuk ayat Al-Qur'an.",
 			"buttons": "Tombol",
-			"buttonsDesc": "Aksi utama, sekunder, dan outline. Mendukung ikon, label, atau keduanya.",
+			"buttonsDesc": "Matriks varian × warna. Pakai varian solid untuk aksi penting, subtle untuk aksi sekunder, outline untuk aksi paling rendah.",
+			"iconButtons": "Tombol Ikon",
+			"iconButtonsDesc": "Tombol bujur sangkar berukuran tetap untuk aksi cepat tanpa label. Wajib mengisi ariaLabel.",
 			"badges": "Badge",
-			"badgesDesc": "Penanda status berukuran kecil — misalnya jenis surat Makkiyah atau Madaniyah.",
+			"badgesDesc": "Penanda status berukuran kecil. Mendukung matriks varian × warna yang sama dengan tombol.",
 			"chips": "Chip / Pill",
 			"chipsDesc": "Pelabelan ringkas atau filter yang bisa dipilih. Mendukung varian warna dan keadaan aktif.",
 			"banners": "Banner / Alert",
@@ -220,9 +222,19 @@
 			"utilityPaletteDesc": "Skala warna utilitas dari Tailwind yang dipakai untuk status (info, sukses, peringatan, error)."
 		},
 		"buttons": {
-			"filled": "Filled",
-			"subtle": "Subtle",
-			"outline": "Outline",
+			"matrix": "Varian × Warna",
+			"matrixDesc": "Setiap kombinasi varian dan warna dapat digunakan sesuai konteks aksi.",
+			"withIcon": "Dengan Ikon",
+			"disabled": "Nonaktif"
+		},
+		"iconButtons": {
+			"sizes": "Ukuran",
+			"variants": "Varian & Warna",
+			"rounded": "Sudut",
+			"disabled": "Nonaktif"
+		},
+		"badges": {
+			"matrix": "Varian × Warna",
 			"withIcon": "Dengan Ikon"
 		},
 		"chips": {

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -39,7 +39,8 @@
 		"sync": "Sinkron",
 		"about": "Tentang",
 		"ayatOfTheDay": "AyatHariIni",
-		"hijriCalendar": "Kalender Hijriyah"
+		"hijriCalendar": "Kalender Hijriyah",
+		"designSystem": "Sistem Desain"
 	},
 	"surah": {
 		"title": "Baca Qur'an",
@@ -176,6 +177,116 @@
 			"perlindungan": "Perlindungan",
 			"sholat": "Sholat",
 			"umum": "Umum"
+		}
+	},
+	"designSystem": {
+		"toc": {
+			"title": "Daftar Isi"
+		},
+		"section": {
+			"colors": "Warna & Token",
+			"colorsDesc": "Token warna inti yang dipakai untuk latar, teks, dan pembatas di seluruh tema.",
+			"themes": "Tema",
+			"typography": "Tipografi",
+			"typographyDesc": "Skala ukuran teks standar serta font Arab khusus untuk ayat Al-Qur'an.",
+			"buttons": "Tombol",
+			"buttonsDesc": "Aksi utama, sekunder, dan outline. Mendukung ikon, label, atau keduanya.",
+			"badges": "Badge",
+			"badgesDesc": "Penanda status berukuran kecil — misalnya jenis surat Makkiyah atau Madaniyah.",
+			"chips": "Chip / Pill",
+			"chipsDesc": "Pelabelan ringkas atau filter yang bisa dipilih. Mendukung varian warna dan keadaan aktif.",
+			"banners": "Banner / Alert",
+			"bannersDesc": "Pesan inline untuk menyampaikan status atau peringatan. Berbeda dengan toast, banner menetap di tempat.",
+			"forms": "Kontrol Form",
+			"formsDesc": "Input, textarea, checkbox, dan radio dengan label dan pesan kesalahan yang konsisten.",
+			"collapsible": "Collapsible",
+			"collapsibleDesc": "Wadah yang bisa dibuka-tutup untuk menyembunyikan detail.",
+			"bottomSheet": "Bottom Sheet",
+			"bottomSheetDesc": "Panel yang muncul dari bawah untuk aksi atau detail kontekstual.",
+			"toasts": "Toast",
+			"toastsDesc": "Notifikasi singkat di pojok atas. Mendukung info, sukses, peringatan, dan error.",
+			"breadcrumb": "Breadcrumb",
+			"breadcrumbDesc": "Jejak navigasi hierarkis menuju halaman saat ini.",
+			"cards": "Kartu",
+			"cardsDesc": "Wadah konten dengan latar sekunder dan bayangan lembut.",
+			"icons": "Ikon",
+			"iconsDesc": "Kumpulan ikon SVG yang dipakai bersama. Semua ikon menerima prop ukuran."
+		},
+		"colors": {
+			"semanticTokens": "Token Semantik",
+			"themePalette": "Palet per Tema",
+			"themePaletteDesc": "Setiap tema memiliki latar dan warna aksen tersendiri. Ganti tema dari ikon di header.",
+			"utilityPalette": "Palet Utilitas",
+			"utilityPaletteDesc": "Skala warna utilitas dari Tailwind yang dipakai untuk status (info, sukses, peringatan, error)."
+		},
+		"buttons": {
+			"filled": "Filled",
+			"subtle": "Subtle",
+			"outline": "Outline",
+			"withIcon": "Dengan Ikon"
+		},
+		"chips": {
+			"interactive": "Chip interaktif — pakai sebagai filter."
+		},
+		"banner": {
+			"infoTitle": "Informasi",
+			"infoBody": "Banner info dipakai untuk pesan netral atau panduan ringan.",
+			"successTitle": "Berhasil",
+			"successBody": "Aksi berhasil dijalankan dan datamu sudah tersimpan.",
+			"warnTitle": "Peringatan",
+			"warnBody": "Periksa kembali masukanmu sebelum melanjutkan.",
+			"errorTitle": "Kesalahan",
+			"errorBody": "Terjadi kesalahan. Coba lagi beberapa saat kemudian.",
+			"dismissibleBody": "Banner ini bisa ditutup. Klik tombol X di kanan untuk menutupnya.",
+			"dismissedHint": "Banner sudah ditutup.",
+			"restore": "Munculkan kembali"
+		},
+		"forms": {
+			"textLabel": "Nama",
+			"textPlaceholder": "Ketik namamu",
+			"textHint": "Hanya disimpan di peramban kamu.",
+			"emailLabel": "Email",
+			"emailError": "Format email tidak valid.",
+			"disabledLabel": "Field nonaktif",
+			"textareaLabel": "Catatan",
+			"textareaPlaceholder": "Tulis catatanmu di sini",
+			"textareaHint": "Maksimal beberapa paragraf.",
+			"checkboxA": "Terima notifikasi",
+			"checkboxAHint": "Hanya pemberitahuan yang penting.",
+			"checkboxB": "Aktifkan auto-next ayat",
+			"checkboxDisabled": "Pilihan ini sedang nonaktif",
+			"radioId": "Bahasa Indonesia",
+			"radioEn": "English",
+			"radioAr": "العربية",
+			"radioArHint": "Hanya tersedia di beberapa halaman.",
+			"selected": "Terpilih:"
+		},
+		"collapsible": {
+			"what": "Apa itu collapsible?",
+			"when": "Kapan dipakai?"
+		},
+		"bottomSheet": {
+			"open": "Buka Bottom Sheet",
+			"demoTitle": "Bottom Sheet Demo"
+		},
+		"cards": {
+			"variants": "Varian",
+			"filledDesc": "Latar sekunder, tanpa bayangan.",
+			"outlineDesc": "Bordir tipis, latar primer.",
+			"elevatedDesc": "Latar sekunder dengan bayangan.",
+			"composed": "Dengan Header & Footer",
+			"withHeaderTitle": "Surat Favorit",
+			"withHeaderBody": "Sematkan surat agar mudah diakses dari halaman utama.",
+			"linkTitle": "Pelajari lebih lanjut",
+			"linkSubtitle": "Buka detail sistem desain",
+			"linkBody": "Kartu yang bisa diklik — render sebagai anchor.",
+			"padding": "Padding",
+			"legacy": "Komponen lama",
+			"legacyDesc": "CardShadow masih dipakai di banyak halaman dan kompatibel dengan tata letak yang ada."
+		},
+		"icons": {
+			"sizes": "Ukuran",
+			"gallery": "Galeri Ikon"
 		}
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -224,6 +224,7 @@
 		"buttons": {
 			"matrix": "Varian × Warna",
 			"matrixDesc": "Setiap kombinasi varian dan warna dapat digunakan sesuai konteks aksi.",
+			"sizes": "Ukuran",
 			"withIcon": "Dengan Ikon",
 			"disabled": "Nonaktif"
 		},
@@ -235,6 +236,7 @@
 		},
 		"badges": {
 			"matrix": "Varian × Warna",
+			"sizes": "Ukuran",
 			"withIcon": "Dengan Ikon"
 		},
 		"chips": {
@@ -271,7 +273,8 @@
 			"radioEn": "English",
 			"radioAr": "العربية",
 			"radioArHint": "Hanya tersedia di beberapa halaman.",
-			"selected": "Terpilih:"
+			"selected": "Terpilih:",
+			"sizes": "Ukuran"
 		},
 		"collapsible": {
 			"what": "Apa itu collapsible?",

--- a/src/lib/ui/Badge.svelte
+++ b/src/lib/ui/Badge.svelte
@@ -1,20 +1,43 @@
 <script lang="ts">
+	type Variant = 'solid' | 'subtle' | 'outline';
+	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+
 	interface Props {
-		color?: 'orange' | 'green';
+		variant?: Variant;
+		color?: Color;
 		children?: import('svelte').Snippet;
 		class?: string;
 	}
 
-	let { color = 'green', children, class: clazz }: Props = $props();
+	let { variant = 'subtle', color = 'secondary', children, class: clazz = '' }: Props = $props();
 
-	const CLASS_BY_COLOR = {
-		orange: 'bg-orange-100 text-orange-600',
-		green: 'bg-green-100 text-green-600'
+	const STYLES: Record<Variant, Record<Color, string>> = {
+		solid: {
+			primary: 'bg-blue-600 text-white',
+			secondary: 'bg-foreground text-primary',
+			success: 'bg-green-600 text-white',
+			warning: 'bg-orange-500 text-white',
+			danger: 'bg-red-600 text-white'
+		},
+		subtle: {
+			primary: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200',
+			secondary: 'bg-secondary text-foreground',
+			success: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200',
+			warning: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200',
+			danger: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200'
+		},
+		outline: {
+			primary: 'border border-blue-500 text-blue-600 dark:text-blue-300',
+			secondary: 'border border-foreground/30 text-foreground',
+			success: 'border border-green-500 text-green-600 dark:text-green-300',
+			warning: 'border border-orange-500 text-orange-600 dark:text-orange-300',
+			danger: 'border border-red-500 text-red-600 dark:text-red-300'
+		}
 	};
 </script>
 
 <span
-	class={`flex items-center gap-2 text-xs cursor-pointer px-1 py-0.5 rounded-lg ${CLASS_BY_COLOR[color]} ${clazz}`}
+	class={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-lg font-medium ${STYLES[variant][color]} ${clazz}`}
 >
 	{@render children?.()}
 </span>

--- a/src/lib/ui/Badge.svelte
+++ b/src/lib/ui/Badge.svelte
@@ -1,15 +1,29 @@
 <script lang="ts">
 	type Variant = 'solid' | 'subtle' | 'outline';
 	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Size = 'sm' | 'md' | 'lg';
 
 	interface Props {
 		variant?: Variant;
 		color?: Color;
+		size?: Size;
 		children?: import('svelte').Snippet;
 		class?: string;
 	}
 
-	let { variant = 'subtle', color = 'secondary', children, class: clazz = '' }: Props = $props();
+	let {
+		variant = 'subtle',
+		color = 'secondary',
+		size = 'md',
+		children,
+		class: clazz = ''
+	}: Props = $props();
+
+	const SIZE_MAP: Record<Size, string> = {
+		sm: 'text-[10px] px-1.5 py-0',
+		md: 'text-xs px-2 py-0.5',
+		lg: 'text-sm px-2.5 py-1'
+	};
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
@@ -37,7 +51,7 @@
 </script>
 
 <span
-	class={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-lg font-medium ${STYLES[variant][color]} ${clazz}`}
+	class={`inline-flex items-center gap-1 rounded-lg font-medium ${SIZE_MAP[size]} ${STYLES[variant][color]} ${clazz}`}
 >
 	{@render children?.()}
 </span>

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import CheckCircleIcon from '$lib/icons/CheckCircleIcon.svelte';
+	import InformationCircleIcon from '$lib/icons/InformationCircleIcon.svelte';
+	import ExclamationTriangleIcon from '$lib/icons/ExclamationTriangleIcon.svelte';
+	import FireIcon from '$lib/icons/FireIcon.svelte';
+	import XMarkIcon from '$lib/icons/XMarkIcon.svelte';
+
+	type BannerType = 'info' | 'success' | 'warn' | 'error';
+
+	interface Props {
+		type?: BannerType;
+		title?: string;
+		dismissible?: boolean;
+		onDismiss?: () => void;
+		ariaLabelClose?: string;
+		children?: import('svelte').Snippet;
+		class?: string;
+	}
+
+	let {
+		type = 'info',
+		title = '',
+		dismissible = false,
+		onDismiss,
+		ariaLabelClose = 'Close',
+		children,
+		class: clazz = ''
+	}: Props = $props();
+
+	const CLASS_MAP = {
+		info: 'border-blue-400 bg-blue-50 text-blue-800 dark:bg-blue-900 dark:text-blue-100',
+		success: 'border-green-400 bg-green-50 text-green-800 dark:bg-green-900 dark:text-green-100',
+		warn: 'border-orange-400 bg-orange-50 text-orange-800 dark:bg-orange-900 dark:text-orange-100',
+		error: 'border-red-400 bg-red-50 text-red-800 dark:bg-red-900 dark:text-red-100'
+	};
+</script>
+
+<div
+	role={type === 'error' || type === 'warn' ? 'alert' : 'status'}
+	data-component="banner"
+	data-type={type}
+	class={`flex items-start gap-3 p-3 rounded-md border-l-4 ${CLASS_MAP[type]} ${clazz}`}
+>
+	<div class="flex-shrink-0 mt-0.5" aria-hidden="true">
+		{#if type === 'info'}
+			<InformationCircleIcon size="sm" />
+		{:else if type === 'success'}
+			<CheckCircleIcon size="sm" />
+		{:else if type === 'warn'}
+			<ExclamationTriangleIcon size="sm" />
+		{:else if type === 'error'}
+			<FireIcon size="sm" />
+		{/if}
+	</div>
+
+	<div class="flex-1 min-w-0 text-sm">
+		{#if title}
+			<div class="font-semibold mb-0.5">{title}</div>
+		{/if}
+		{@render children?.()}
+	</div>
+
+	{#if dismissible}
+		<button
+			type="button"
+			onclick={() => onDismiss?.()}
+			aria-label={ariaLabelClose}
+			class="flex-shrink-0 -m-1 p-1 rounded hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+		>
+			<XMarkIcon size="sm" />
+		</button>
+	{/if}
+</div>

--- a/src/lib/ui/Button.svelte
+++ b/src/lib/ui/Button.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	type Variant = 'solid' | 'subtle' | 'outline';
 	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Size = 'sm' | 'md' | 'lg';
 
 	interface Props {
 		onClick: (event: MouseEvent) => void;
 		variant?: Variant;
 		color?: Color;
+		size?: Size;
 		ariaLabel?: string;
 		disabled?: boolean;
 		children?: import('svelte').Snippet;
@@ -17,12 +19,19 @@
 		onClick,
 		variant = 'solid',
 		color = 'secondary',
+		size = 'md',
 		ariaLabel = '',
 		disabled = false,
 		children,
 		class: clazz = '',
 		...rest
 	}: Props = $props();
+
+	const SIZE_MAP: Record<Size, string> = {
+		sm: 'text-xs px-2 py-1 gap-1',
+		md: 'text-sm px-3 py-2 gap-2',
+		lg: 'text-base px-4 py-2.5 gap-2'
+	};
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
@@ -61,7 +70,7 @@
 	onclick={onClick}
 	{disabled}
 	aria-label={ariaLabel}
-	class={`flex items-center gap-2 p-2 rounded-md transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
+	class={`flex items-center rounded-md transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${SIZE_MAP[size]} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
 	{...rest}
 >
 	{@render children?.()}

--- a/src/lib/ui/Card.svelte
+++ b/src/lib/ui/Card.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	interface Props {
+		variant?: 'filled' | 'outline' | 'elevated';
+		padding?: 'none' | 'sm' | 'md' | 'lg';
+		as?: 'div' | 'a' | 'article' | 'section';
+		href?: string;
+		id?: string;
+		title?: string;
+		subtitle?: string;
+		header?: import('svelte').Snippet;
+		footer?: import('svelte').Snippet;
+		children?: import('svelte').Snippet;
+		class?: string;
+	}
+
+	let {
+		variant = 'filled',
+		padding = 'md',
+		as = 'div',
+		href = '',
+		id = '',
+		title = '',
+		subtitle = '',
+		header,
+		footer,
+		children,
+		class: clazz = ''
+	}: Props = $props();
+
+	const VARIANT_MAP = {
+		filled: 'bg-secondary',
+		outline: 'bg-primary border border-foreground/20',
+		elevated: 'bg-secondary shadow-md'
+	};
+
+	const PADDING_MAP = {
+		none: 'p-0',
+		sm: 'p-3',
+		md: 'p-4',
+		lg: 'p-6'
+	};
+
+	const baseClass = $derived(
+		`relative rounded-lg overflow-hidden ${VARIANT_MAP[variant]} ${clazz}`
+	);
+	const contentPadding = $derived(PADDING_MAP[padding]);
+	const isInteractive = $derived(as === 'a' && Boolean(href));
+	const interactiveClass = $derived(
+		isInteractive ? 'block hover:shadow-md transition-shadow focus:ring-2 focus:ring-blue-500' : ''
+	);
+
+	const showHeader = $derived(Boolean(header || title || subtitle));
+</script>
+
+{#snippet inner()}
+	{#if showHeader}
+		<div class={`${contentPadding} ${footer || children ? 'border-b border-foreground/10' : ''}`}>
+			{#if header}
+				{@render header()}
+			{:else}
+				{#if title}<h3 class="font-semibold">{title}</h3>{/if}
+				{#if subtitle}<p class="text-xs opacity-75 mt-0.5">{subtitle}</p>{/if}
+			{/if}
+		</div>
+	{/if}
+
+	{#if children}
+		<div class={contentPadding}>
+			{@render children()}
+		</div>
+	{/if}
+
+	{#if footer}
+		<div class={`${contentPadding} border-t border-foreground/10 bg-primary/40`}>
+			{@render footer()}
+		</div>
+	{/if}
+{/snippet}
+
+{#if as === 'a'}
+	<a class={`${baseClass} ${interactiveClass}`} {href} {id}>
+		{@render inner()}
+	</a>
+{:else if as === 'article'}
+	<article class={baseClass} {id}>
+		{@render inner()}
+	</article>
+{:else if as === 'section'}
+	<section class={baseClass} {id}>
+		{@render inner()}
+	</section>
+{:else}
+	<div class={baseClass} {id}>
+		{@render inner()}
+	</div>
+{/if}

--- a/src/lib/ui/Checkbox.svelte
+++ b/src/lib/ui/Checkbox.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		checked?: boolean;
+		label?: string;
+		hint?: string;
+		id?: string;
+		name?: string;
+		value?: string;
+		disabled?: boolean;
+		onChange?: (event: Event) => void;
+		class?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		checked = $bindable(false),
+		label = '',
+		hint = '',
+		id = '',
+		name = '',
+		value = '',
+		disabled = false,
+		onChange,
+		class: clazz = '',
+		children
+	}: Props = $props();
+
+	const fieldId = $derived(id || `checkbox-${name || Math.random().toString(36).slice(2, 8)}`);
+</script>
+
+<label
+	for={fieldId}
+	class={`flex items-start gap-2 cursor-pointer ${disabled ? 'opacity-60 cursor-not-allowed' : ''} ${clazz}`}
+>
+	<input
+		id={fieldId}
+		{name}
+		{value}
+		{disabled}
+		type="checkbox"
+		bind:checked
+		onchange={onChange}
+		class="mt-0.5 w-4 h-4 rounded text-blue-600 bg-secondary border-foreground/30 focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+	/>
+	<span class="flex flex-col">
+		{#if label}<span class="text-sm">{label}</span>{/if}
+		{@render children?.()}
+		{#if hint}<span class="text-xs opacity-75">{hint}</span>{/if}
+	</span>
+</label>

--- a/src/lib/ui/Chip.svelte
+++ b/src/lib/ui/Chip.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	interface Props {
+		color?: 'neutral' | 'blue' | 'green' | 'orange' | 'red' | 'purple';
+		size?: 'sm' | 'md';
+		active?: boolean;
+		onClick?: (event: MouseEvent) => void;
+		ariaLabel?: string;
+		children?: import('svelte').Snippet;
+		class?: string;
+	}
+
+	let {
+		color = 'neutral',
+		size = 'md',
+		active = false,
+		onClick,
+		ariaLabel = '',
+		children,
+		class: clazz = ''
+	}: Props = $props();
+
+	const COLOR_MAP = {
+		neutral: 'bg-secondary text-foreground',
+		blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200',
+		green: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200',
+		orange: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200',
+		red: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200',
+		purple: 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200'
+	};
+
+	const SIZE_MAP = {
+		sm: 'text-xs px-2 py-0.5',
+		md: 'text-sm px-3 py-1'
+	};
+
+	const activeRing = $derived(active ? 'ring-2 ring-blue-500' : '');
+</script>
+
+{#if onClick}
+	<button
+		type="button"
+		onclick={onClick}
+		aria-label={ariaLabel}
+		aria-pressed={active}
+		class={`inline-flex items-center gap-1 rounded-full font-medium cursor-pointer transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-blue-500 ${COLOR_MAP[color]} ${SIZE_MAP[size]} ${activeRing} ${clazz}`}
+	>
+		{@render children?.()}
+	</button>
+{:else}
+	<span
+		class={`inline-flex items-center gap-1 rounded-full font-medium ${COLOR_MAP[color]} ${SIZE_MAP[size]} ${activeRing} ${clazz}`}
+	>
+		{@render children?.()}
+	</span>
+{/if}

--- a/src/lib/ui/Collapsible.svelte
+++ b/src/lib/ui/Collapsible.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import ChevronDownIcon from '$lib/icons/ChevronDownIcon.svelte';
+
+	interface Props {
+		title: string;
+		open?: boolean;
+		id?: string;
+		children?: import('svelte').Snippet;
+		class?: string;
+	}
+
+	let { title, open = false, id = '', children, class: clazz = '' }: Props = $props();
+
+	let isOpen = $state(open);
+
+	function toggle() {
+		isOpen = !isOpen;
+	}
+</script>
+
+<div
+	data-component="collapsible"
+	data-id={id}
+	data-open={isOpen}
+	class={`rounded-md border border-secondary bg-secondary/40 overflow-hidden ${clazz}`}
+>
+	<button
+		type="button"
+		onclick={toggle}
+		aria-expanded={isOpen}
+		class="flex w-full items-center justify-between gap-2 p-3 text-left cursor-pointer hover:bg-secondary focus:outline-none focus:bg-secondary"
+	>
+		<span class="font-semibold">{title}</span>
+		<span
+			class={`inline-flex transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+			aria-hidden="true"
+		>
+			<ChevronDownIcon size="sm" />
+		</span>
+	</button>
+
+	{#if isOpen}
+		<div class="p-3 border-t border-foreground/10">
+			{@render children?.()}
+		</div>
+	{/if}
+</div>

--- a/src/lib/ui/IconButton.svelte
+++ b/src/lib/ui/IconButton.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-	type Variant = 'solid' | 'subtle' | 'outline';
+	type Variant = 'solid' | 'subtle' | 'outline' | 'ghost';
 	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Size = 'xs' | 'sm' | 'md' | 'lg';
 
 	interface Props {
 		onClick: (event: MouseEvent) => void;
 		variant?: Variant;
 		color?: Color;
-		ariaLabel?: string;
+		size?: Size;
+		ariaLabel: string;
 		disabled?: boolean;
+		rounded?: 'md' | 'full';
 		children?: import('svelte').Snippet;
 		class?: string;
 		[key: `data-${string}`]: string | undefined;
@@ -15,14 +18,23 @@
 
 	let {
 		onClick,
-		variant = 'solid',
+		variant = 'ghost',
 		color = 'secondary',
-		ariaLabel = '',
+		size = 'md',
+		ariaLabel,
 		disabled = false,
+		rounded = 'md',
 		children,
 		class: clazz = '',
 		...rest
 	}: Props = $props();
+
+	const SIZE_MAP: Record<Size, string> = {
+		xs: 'w-6 h-6',
+		sm: 'w-8 h-8',
+		md: 'w-10 h-10',
+		lg: 'w-12 h-12'
+	};
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
@@ -42,26 +54,29 @@
 			danger: 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-100'
 		},
 		outline: {
-			primary:
-				'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-900/40',
+			primary: 'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300',
 			secondary: 'border border-foreground/30 text-foreground hover:bg-secondary',
-			success:
-				'border border-green-500 text-green-600 hover:bg-green-50 dark:text-green-300 dark:hover:bg-green-900/40',
+			success: 'border border-green-500 text-green-600 hover:bg-green-50 dark:text-green-300',
+			warning: 'border border-orange-500 text-orange-600 hover:bg-orange-50 dark:text-orange-300',
+			danger: 'border border-red-500 text-red-600 hover:bg-red-50 dark:text-red-300'
+		},
+		ghost: {
+			primary: 'text-blue-600 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/40',
+			secondary: 'text-foreground hover:bg-secondary',
+			success: 'text-green-600 hover:bg-green-100 dark:text-green-300 dark:hover:bg-green-900/40',
 			warning:
-				'border border-orange-500 text-orange-600 hover:bg-orange-50 dark:text-orange-300 dark:hover:bg-orange-900/40',
-			danger:
-				'border border-red-500 text-red-600 hover:bg-red-50 dark:text-red-300 dark:hover:bg-red-900/40'
+				'text-orange-600 hover:bg-orange-100 dark:text-orange-300 dark:hover:bg-orange-900/40',
+			danger: 'text-red-600 hover:bg-red-100 dark:text-red-300 dark:hover:bg-red-900/40'
 		}
 	};
 </script>
 
 <button
 	type="button"
-	tabindex="0"
 	onclick={onClick}
 	{disabled}
 	aria-label={ariaLabel}
-	class={`flex items-center gap-2 p-2 rounded-md transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
+	class={`inline-flex items-center justify-center transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${SIZE_MAP[size]} ${rounded === 'full' ? 'rounded-full' : 'rounded-md'} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
 	{...rest}
 >
 	{@render children?.()}

--- a/src/lib/ui/Input.svelte
+++ b/src/lib/ui/Input.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	type Size = 'sm' | 'md' | 'lg';
+
 	interface Props {
 		value?: string;
 		type?: 'text' | 'search' | 'email' | 'password' | 'number' | 'tel' | 'url';
@@ -8,6 +10,7 @@
 		error?: string;
 		id?: string;
 		name?: string;
+		size?: Size;
 		required?: boolean;
 		disabled?: boolean;
 		readonly?: boolean;
@@ -25,6 +28,7 @@
 		error = '',
 		id = '',
 		name = '',
+		size = 'md',
 		required = false,
 		disabled = false,
 		readonly = false,
@@ -35,6 +39,12 @@
 
 	const fieldId = $derived(id || `input-${name || Math.random().toString(36).slice(2, 8)}`);
 	const hasError = $derived(Boolean(error));
+
+	const SIZE_MAP: Record<Size, string> = {
+		sm: 'text-sm p-2',
+		md: 'text-md p-2.5',
+		lg: 'text-lg p-3'
+	};
 </script>
 
 <div class={`flex flex-col gap-1 ${clazz}`}>
@@ -58,7 +68,7 @@
 		onchange={onChange}
 		aria-invalid={hasError}
 		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
-		class={`text-md border-0 rounded-lg block p-2.5 placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+		class={`border-0 rounded-lg block placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none ${SIZE_MAP[size]} ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
 	/>
 
 	{#if hasError}

--- a/src/lib/ui/Input.svelte
+++ b/src/lib/ui/Input.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	interface Props {
+		value?: string;
+		type?: 'text' | 'search' | 'email' | 'password' | 'number' | 'tel' | 'url';
+		placeholder?: string;
+		label?: string;
+		hint?: string;
+		error?: string;
+		id?: string;
+		name?: string;
+		required?: boolean;
+		disabled?: boolean;
+		readonly?: boolean;
+		onInput?: (event: Event) => void;
+		onChange?: (event: Event) => void;
+		class?: string;
+	}
+
+	let {
+		value = $bindable(''),
+		type = 'text',
+		placeholder = '',
+		label = '',
+		hint = '',
+		error = '',
+		id = '',
+		name = '',
+		required = false,
+		disabled = false,
+		readonly = false,
+		onInput,
+		onChange,
+		class: clazz = ''
+	}: Props = $props();
+
+	const fieldId = $derived(id || `input-${name || Math.random().toString(36).slice(2, 8)}`);
+	const hasError = $derived(Boolean(error));
+</script>
+
+<div class={`flex flex-col gap-1 ${clazz}`}>
+	{#if label}
+		<label for={fieldId} class="text-sm font-medium">
+			{label}
+			{#if required}<span aria-hidden="true" class="text-red-500">*</span>{/if}
+		</label>
+	{/if}
+
+	<input
+		id={fieldId}
+		{name}
+		{type}
+		{placeholder}
+		{required}
+		{disabled}
+		{readonly}
+		bind:value
+		oninput={onInput}
+		onchange={onChange}
+		aria-invalid={hasError}
+		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
+		class={`text-md border-0 rounded-lg block p-2.5 placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+	/>
+
+	{#if hasError}
+		<p id={`${fieldId}-error`} class="text-xs text-red-500">{error}</p>
+	{:else if hint}
+		<p id={`${fieldId}-hint`} class="text-xs opacity-75">{hint}</p>
+	{/if}
+</div>

--- a/src/lib/ui/Radio.svelte
+++ b/src/lib/ui/Radio.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		group?: string;
+		value: string;
+		label?: string;
+		hint?: string;
+		id?: string;
+		name?: string;
+		disabled?: boolean;
+		onChange?: (event: Event) => void;
+		class?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		group = $bindable(''),
+		value,
+		label = '',
+		hint = '',
+		id = '',
+		name = '',
+		disabled = false,
+		onChange,
+		class: clazz = '',
+		children
+	}: Props = $props();
+
+	const fieldId = $derived(id || `radio-${name || value}`);
+</script>
+
+<label
+	for={fieldId}
+	class={`flex items-start gap-2 cursor-pointer ${disabled ? 'opacity-60 cursor-not-allowed' : ''} ${clazz}`}
+>
+	<input
+		id={fieldId}
+		{name}
+		{value}
+		{disabled}
+		type="radio"
+		bind:group
+		onchange={onChange}
+		class="mt-0.5 w-4 h-4 text-blue-600 bg-secondary border-foreground/30 focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+	/>
+	<span class="flex flex-col">
+		{#if label}<span class="text-sm">{label}</span>{/if}
+		{@render children?.()}
+		{#if hint}<span class="text-xs opacity-75">{hint}</span>{/if}
+	</span>
+</label>

--- a/src/lib/ui/Textarea.svelte
+++ b/src/lib/ui/Textarea.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	interface Props {
+		value?: string;
+		placeholder?: string;
+		label?: string;
+		hint?: string;
+		error?: string;
+		id?: string;
+		name?: string;
+		rows?: number;
+		required?: boolean;
+		disabled?: boolean;
+		readonly?: boolean;
+		onInput?: (event: Event) => void;
+		onChange?: (event: Event) => void;
+		class?: string;
+	}
+
+	let {
+		value = $bindable(''),
+		placeholder = '',
+		label = '',
+		hint = '',
+		error = '',
+		id = '',
+		name = '',
+		rows = 4,
+		required = false,
+		disabled = false,
+		readonly = false,
+		onInput,
+		onChange,
+		class: clazz = ''
+	}: Props = $props();
+
+	const fieldId = $derived(id || `textarea-${name || Math.random().toString(36).slice(2, 8)}`);
+	const hasError = $derived(Boolean(error));
+</script>
+
+<div class={`flex flex-col gap-1 ${clazz}`}>
+	{#if label}
+		<label for={fieldId} class="text-sm font-medium">
+			{label}
+			{#if required}<span aria-hidden="true" class="text-red-500">*</span>{/if}
+		</label>
+	{/if}
+
+	<textarea
+		id={fieldId}
+		{name}
+		{placeholder}
+		{rows}
+		{required}
+		{disabled}
+		{readonly}
+		bind:value
+		oninput={onInput}
+		onchange={onChange}
+		aria-invalid={hasError}
+		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
+		class={`text-md border-0 rounded-lg block p-2.5 placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none resize-y ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+	></textarea>
+
+	{#if hasError}
+		<p id={`${fieldId}-error`} class="text-xs text-red-500">{error}</p>
+	{:else if hint}
+		<p id={`${fieldId}-hint`} class="text-xs opacity-75">{hint}</p>
+	{/if}
+</div>

--- a/src/lib/ui/Textarea.svelte
+++ b/src/lib/ui/Textarea.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	type Size = 'sm' | 'md' | 'lg';
+
 	interface Props {
 		value?: string;
 		placeholder?: string;
@@ -7,6 +9,7 @@
 		error?: string;
 		id?: string;
 		name?: string;
+		size?: Size;
 		rows?: number;
 		required?: boolean;
 		disabled?: boolean;
@@ -24,6 +27,7 @@
 		error = '',
 		id = '',
 		name = '',
+		size = 'md',
 		rows = 4,
 		required = false,
 		disabled = false,
@@ -35,6 +39,12 @@
 
 	const fieldId = $derived(id || `textarea-${name || Math.random().toString(36).slice(2, 8)}`);
 	const hasError = $derived(Boolean(error));
+
+	const SIZE_MAP: Record<Size, string> = {
+		sm: 'text-sm p-2',
+		md: 'text-md p-2.5',
+		lg: 'text-lg p-3'
+	};
 </script>
 
 <div class={`flex flex-col gap-1 ${clazz}`}>
@@ -58,7 +68,7 @@
 		onchange={onChange}
 		aria-invalid={hasError}
 		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
-		class={`text-md border-0 rounded-lg block p-2.5 placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none resize-y ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+		class={`border-0 rounded-lg block placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none resize-y ${SIZE_MAP[size]} ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
 	></textarea>
 
 	{#if hasError}

--- a/src/routes/asmaul-husna/+page.svelte
+++ b/src/routes/asmaul-husna/+page.svelte
@@ -32,7 +32,7 @@
 				<div class="flex gap-2 items-center">
 					<div class="flex flex-col items-start justify-center">
 						<div class="flex gap-2 mb-2">
-							<Badge color="green">
+							<Badge color="success">
 								{index + 1}
 							</Badge>
 							<span class="font-bold">{item.latin}</span>

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -3,6 +3,7 @@
 	import MetaTag from '$lib/MetaTag.svelte';
 	import CardShadow from '$lib/CardShadow.svelte';
 	import Button from '$lib/ui/Button.svelte';
+	import IconButton from '$lib/ui/IconButton.svelte';
 	import Badge from '$lib/ui/Badge.svelte';
 	import Chip from '$lib/ui/Chip.svelte';
 	import Collapsible from '$lib/ui/Collapsible.svelte';
@@ -38,6 +39,7 @@
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import ChevronUpIcon from '$lib/icons/ChevronUpIcon.svelte';
 	import ChevronDownIcon from '$lib/icons/ChevronDownIcon.svelte';
+	import HashtagIcon from '$lib/icons/HashtagIcon.svelte';
 
 	import type { IconSize } from '$lib/icons/utils';
 
@@ -101,6 +103,7 @@
 		{ id: 'colors', label: $t('designSystem.section.colors') },
 		{ id: 'typography', label: $t('designSystem.section.typography') },
 		{ id: 'buttons', label: $t('designSystem.section.buttons') },
+		{ id: 'icon-buttons', label: $t('designSystem.section.iconButtons') },
 		{ id: 'badges', label: $t('designSystem.section.badges') },
 		{ id: 'chips', label: $t('designSystem.section.chips') },
 		{ id: 'banners', label: $t('designSystem.section.banners') },
@@ -291,33 +294,247 @@
 		<p class="text-sm opacity-75">{$t('designSystem.section.buttonsDesc')}</p>
 
 		<CardShadow class="flex flex-col gap-4">
-			<div class="flex flex-wrap items-center gap-3">
-				<Button onClick={() => showToast('info')}>
-					<span>{$t('designSystem.buttons.filled')}</span>
-				</Button>
-				<Button variant="subtle" onClick={() => showToast('info')}>
-					<span>{$t('designSystem.buttons.subtle')}</span>
-				</Button>
-				<Button variant="outline" onClick={() => showToast('info')}>
-					<span>{$t('designSystem.buttons.outline')}</span>
-				</Button>
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.buttons.matrix')}</h3>
+				<p class="text-xs opacity-75">{$t('designSystem.buttons.matrixDesc')}</p>
+				<div class="overflow-x-auto">
+					<table class="text-sm">
+						<thead>
+							<tr class="text-left">
+								<th class="px-2 py-1"></th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">primary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">secondary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">success</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">warning</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">danger</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">solid</td>
+								<td class="px-2 py-1">
+									<Button color="primary" onClick={() => showToast('info')}>Action</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button color="secondary" onClick={() => showToast('info')}>Action</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button color="success" onClick={() => showToast('success')}>Save</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button color="warning" onClick={() => showToast('warn')}>Review</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button color="danger" onClick={() => showToast('error')}>Delete</Button>
+								</td>
+							</tr>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">subtle</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="primary" onClick={() => showToast('info')}>
+										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="secondary" onClick={() => showToast('info')}>
+										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="success" onClick={() => showToast('success')}>
+										Save
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="warning" onClick={() => showToast('warn')}>
+										Review
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="danger" onClick={() => showToast('error')}>
+										Delete
+									</Button>
+								</td>
+							</tr>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">outline</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="primary" onClick={() => showToast('info')}>
+										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="secondary" onClick={() => showToast('info')}>
+										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="success" onClick={() => showToast('success')}>
+										Save
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="warning" onClick={() => showToast('warn')}>
+										Review
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="danger" onClick={() => showToast('error')}>
+										Delete
+									</Button>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
 			</div>
 
-			<div class="flex flex-wrap items-center gap-3">
-				<Button onClick={() => showToast('success')} ariaLabel="Bookmark">
-					<BookmarkIcon size="sm" />
-					<span>{$t('designSystem.buttons.withIcon')}</span>
-				</Button>
-				<Button variant="subtle" onClick={() => showToast('success')} ariaLabel="Share">
-					<ShareIcon size="sm" />
-				</Button>
-				<Button variant="outline" onClick={() => showToast('success')} ariaLabel="Play">
-					<PlayIcon size="sm" />
-				</Button>
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.buttons.withIcon')}</h3>
+				<div class="flex flex-wrap items-center gap-3">
+					<Button color="primary" onClick={() => showToast('success')} ariaLabel="Bookmark">
+						<BookmarkIcon size="sm" />
+						<span>Bookmark</span>
+					</Button>
+					<Button variant="subtle" onClick={() => showToast('success')} ariaLabel="Share">
+						<ShareIcon size="sm" />
+					</Button>
+					<Button variant="outline" color="success" onClick={() => showToast('success')}>
+						<PlayIcon size="sm" />
+						<span>Play</span>
+					</Button>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.buttons.disabled')}</h3>
+				<div class="flex flex-wrap items-center gap-3">
+					<Button color="primary" disabled onClick={() => {}}>Disabled</Button>
+					<Button variant="subtle" color="danger" disabled onClick={() => {}}>Disabled</Button>
+					<Button variant="outline" color="success" disabled onClick={() => {}}>Disabled</Button>
+				</div>
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Button variant="filled | subtle | outline" onClick={fn}>...</Button>'}</code
+					>{'<Button variant="solid | subtle | outline"\n        color="primary | secondary | success | warning | danger"\n        disabled\n        onClick={fn}>...</Button>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- ICON BUTTONS -->
+	<section id="icon-buttons" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.iconButtons')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.iconButtonsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.iconButtons.sizes')}</h3>
+				<div class="flex items-end gap-3">
+					<IconButton size="xs" ariaLabel="xs share" onClick={() => showToast('info')}>
+						<ShareIcon size="xs" />
+					</IconButton>
+					<IconButton size="sm" ariaLabel="sm share" onClick={() => showToast('info')}>
+						<ShareIcon size="sm" />
+					</IconButton>
+					<IconButton size="md" ariaLabel="md share" onClick={() => showToast('info')}>
+						<ShareIcon size="sm" />
+					</IconButton>
+					<IconButton size="lg" ariaLabel="lg share" onClick={() => showToast('info')}>
+						<ShareIcon size="md" />
+					</IconButton>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.iconButtons.variants')}</h3>
+				<div class="flex flex-wrap items-center gap-2">
+					<IconButton
+						variant="ghost"
+						color="secondary"
+						ariaLabel="ghost"
+						onClick={() => showToast('info')}
+					>
+						<HeartIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="subtle"
+						color="primary"
+						ariaLabel="subtle"
+						onClick={() => showToast('info')}
+					>
+						<HeartIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="outline"
+						color="secondary"
+						ariaLabel="outline"
+						onClick={() => showToast('info')}
+					>
+						<HeartIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="solid"
+						color="primary"
+						ariaLabel="solid primary"
+						onClick={() => showToast('info')}
+					>
+						<HeartSolidIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="solid"
+						color="danger"
+						ariaLabel="solid danger"
+						onClick={() => showToast('error')}
+					>
+						<XMarkIcon size="sm" />
+					</IconButton>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.iconButtons.rounded')}</h3>
+				<div class="flex flex-wrap items-center gap-2">
+					<IconButton
+						variant="solid"
+						color="primary"
+						rounded="md"
+						ariaLabel="rounded md"
+						onClick={() => showToast('info')}
+					>
+						<PlayIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="solid"
+						color="primary"
+						rounded="full"
+						ariaLabel="rounded full"
+						onClick={() => showToast('info')}
+					>
+						<PlayIcon size="sm" />
+					</IconButton>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.iconButtons.disabled')}</h3>
+				<div class="flex flex-wrap items-center gap-2">
+					<IconButton variant="ghost" disabled ariaLabel="disabled ghost" onClick={() => {}}>
+						<XMarkIcon size="sm" />
+					</IconButton>
+					<IconButton
+						variant="solid"
+						color="primary"
+						disabled
+						ariaLabel="disabled solid"
+						onClick={() => {}}
+					>
+						<XMarkIcon size="sm" />
+					</IconButton>
+				</div>
+			</div>
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<IconButton variant="ghost | subtle | outline | solid"\n            color="primary | secondary | success | warning | danger"\n            size="xs | sm | md | lg"\n            rounded="md | full"\n            ariaLabel="…"\n            onClick={fn}>\n  <Icon size="sm" />\n</IconButton>'}</code
 				></pre>
 		</CardShadow>
 	</section>
@@ -327,17 +544,72 @@
 		<h2 class="text-xl font-bold">{$t('designSystem.section.badges')}</h2>
 		<p class="text-sm opacity-75">{$t('designSystem.section.badgesDesc')}</p>
 
-		<CardShadow class="flex flex-col gap-3">
-			<div class="flex flex-wrap items-center gap-3">
-				<Badge>Makkiyah</Badge>
-				<Badge color="orange">Madaniyah</Badge>
-				<Badge>
-					<CheckCircleIcon size="xs" />
-					{isEnglish ? 'Verified' : 'Terverifikasi'}
-				</Badge>
+		<CardShadow class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.badges.matrix')}</h3>
+				<div class="overflow-x-auto">
+					<table class="text-sm">
+						<thead>
+							<tr class="text-left">
+								<th class="px-2 py-1"></th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">primary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">secondary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">success</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">warning</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">danger</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">solid</td>
+								<td class="px-2 py-1"><Badge variant="solid" color="primary">New</Badge></td>
+								<td class="px-2 py-1"><Badge variant="solid" color="secondary">Default</Badge></td>
+								<td class="px-2 py-1"><Badge variant="solid" color="success">Done</Badge></td>
+								<td class="px-2 py-1"><Badge variant="solid" color="warning">Hold</Badge></td>
+								<td class="px-2 py-1"><Badge variant="solid" color="danger">Fail</Badge></td>
+							</tr>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">subtle</td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="primary">New</Badge></td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="secondary">Default</Badge></td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="success">Done</Badge></td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="warning">Hold</Badge></td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="danger">Fail</Badge></td>
+							</tr>
+							<tr>
+								<td class="px-2 py-1 text-xs opacity-75">outline</td>
+								<td class="px-2 py-1"><Badge variant="outline" color="primary">New</Badge></td>
+								<td class="px-2 py-1"><Badge variant="outline" color="secondary">Default</Badge></td
+								>
+								<td class="px-2 py-1"><Badge variant="outline" color="success">Done</Badge></td>
+								<td class="px-2 py-1"><Badge variant="outline" color="warning">Hold</Badge></td>
+								<td class="px-2 py-1"><Badge variant="outline" color="danger">Fail</Badge></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
 			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.badges.withIcon')}</h3>
+				<div class="flex flex-wrap items-center gap-3">
+					<Badge variant="subtle" color="success">
+						<CheckCircleIcon size="xs" />
+						{isEnglish ? 'Verified' : 'Terverifikasi'}
+					</Badge>
+					<Badge variant="solid" color="primary">
+						<HashtagIcon size="xs" />
+						123
+					</Badge>
+					<Badge variant="outline" color="warning">
+						<ExclamationTriangleIcon size="xs" />
+						{isEnglish ? 'Beta' : 'Beta'}
+					</Badge>
+				</div>
+			</div>
+
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Badge color="green | orange">label</Badge>'}</code
+					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | success | warning | danger">label</Badge>'}</code
 				></pre>
 		</CardShadow>
 	</section>

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -390,6 +390,15 @@
 			</div>
 
 			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.buttons.sizes')}</h3>
+				<div class="flex flex-wrap items-center gap-3">
+					<Button size="sm" color="primary" onClick={() => showToast('info')}>sm</Button>
+					<Button size="md" color="primary" onClick={() => showToast('info')}>md</Button>
+					<Button size="lg" color="primary" onClick={() => showToast('info')}>lg</Button>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
 				<h3 class="font-semibold">{$t('designSystem.buttons.withIcon')}</h3>
 				<div class="flex flex-wrap items-center gap-3">
 					<Button color="primary" onClick={() => showToast('success')} ariaLabel="Bookmark">
@@ -416,7 +425,7 @@
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Button variant="solid | subtle | outline"\n        color="primary | secondary | success | warning | danger"\n        disabled\n        onClick={fn}>...</Button>'}</code
+					>{'<Button variant="solid | subtle | outline"\n        color="primary | secondary | success | warning | danger"\n        size="sm | md | lg"\n        disabled\n        onClick={fn}>...</Button>'}</code
 				></pre>
 		</CardShadow>
 	</section>
@@ -591,6 +600,15 @@
 			</div>
 
 			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.badges.sizes')}</h3>
+				<div class="flex flex-wrap items-center gap-3">
+					<Badge size="sm" color="primary">sm</Badge>
+					<Badge size="md" color="primary">md</Badge>
+					<Badge size="lg" color="primary">lg</Badge>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
 				<h3 class="font-semibold">{$t('designSystem.badges.withIcon')}</h3>
 				<div class="flex flex-wrap items-center gap-3">
 					<Badge variant="subtle" color="success">
@@ -609,7 +627,7 @@
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | success | warning | danger">label</Badge>'}</code
+					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | success | warning | danger"\n       size="sm | md | lg">label</Badge>'}</code
 				></pre>
 		</CardShadow>
 	</section>
@@ -733,8 +751,15 @@
 			/>
 			<Input label={$t('designSystem.forms.disabledLabel')} value="readonly" disabled />
 
+			<div class="flex flex-col gap-2">
+				<h4 class="text-sm font-semibold">{$t('designSystem.forms.sizes')}</h4>
+				<Input size="sm" placeholder="size=sm" />
+				<Input size="md" placeholder="size=md" />
+				<Input size="lg" placeholder="size=lg" />
+			</div>
+
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Input label="..." bind:value error="..." hint="..." />'}</code
+					>{'<Input label="..." size="sm | md | lg" bind:value error="..." hint="..." />'}</code
 				></pre>
 		</CardShadow>
 
@@ -747,8 +772,15 @@
 				rows={3}
 				bind:value={demoTextarea}
 			/>
+
+			<div class="flex flex-col gap-2">
+				<h4 class="text-sm font-semibold">{$t('designSystem.forms.sizes')}</h4>
+				<Textarea size="sm" rows={2} placeholder="size=sm" />
+				<Textarea size="lg" rows={2} placeholder="size=lg" />
+			</div>
+
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Textarea label="..." rows={4} bind:value />'}</code
+					>{'<Textarea label="..." size="sm | md | lg" rows={4} bind:value />'}</code
 				></pre>
 		</CardShadow>
 

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -1,0 +1,767 @@
+<script lang="ts">
+	import Breadcrumb from '$lib/Breadcrumb.svelte';
+	import MetaTag from '$lib/MetaTag.svelte';
+	import CardShadow from '$lib/CardShadow.svelte';
+	import Button from '$lib/ui/Button.svelte';
+	import Badge from '$lib/ui/Badge.svelte';
+	import Chip from '$lib/ui/Chip.svelte';
+	import Collapsible from '$lib/ui/Collapsible.svelte';
+	import BottomSheet from '$lib/ui/BottomSheet.svelte';
+	import Card from '$lib/ui/Card.svelte';
+	import Banner from '$lib/ui/Banner.svelte';
+	import Input from '$lib/ui/Input.svelte';
+	import Textarea from '$lib/ui/Textarea.svelte';
+	import Checkbox from '$lib/ui/Checkbox.svelte';
+	import Radio from '$lib/ui/Radio.svelte';
+	import { TITLE_CONSTANTS, THEMES } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import { t } from '$lib/translations/store';
+	import { toast } from '../../store/toast';
+
+	import BookmarkIcon from '$lib/icons/BookmarkIcon.svelte';
+	import BookmarkSolidIcon from '$lib/icons/BookmarkSolidIcon.svelte';
+	import HeartIcon from '$lib/icons/HeartIcon.svelte';
+	import HeartSolidIcon from '$lib/icons/HeartSolidIcon.svelte';
+	import ShareIcon from '$lib/icons/ShareIcon.svelte';
+	import CopyIcon from '$lib/icons/CopyIcon.svelte';
+	import PlayIcon from '$lib/icons/PlayIcon.svelte';
+	import PauseIcon from '$lib/icons/PauseIcon.svelte';
+	import HomeIcon from '$lib/icons/HomeIcon.svelte';
+	import SettingIcon from '$lib/icons/SettingIcon.svelte';
+	import SearchIcon from '$lib/icons/SearchIcon.svelte';
+	import XMarkIcon from '$lib/icons/XMarkIcon.svelte';
+	import CheckCircleIcon from '$lib/icons/CheckCircleIcon.svelte';
+	import FireIcon from '$lib/icons/FireIcon.svelte';
+	import InformationCircleIcon from '$lib/icons/InformationCircleIcon.svelte';
+	import ExclamationTriangleIcon from '$lib/icons/ExclamationTriangleIcon.svelte';
+	import ArrowLeftIcon from '$lib/icons/ArrowLeftIcon.svelte';
+	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
+	import ChevronUpIcon from '$lib/icons/ChevronUpIcon.svelte';
+	import ChevronDownIcon from '$lib/icons/ChevronDownIcon.svelte';
+
+	import type { IconSize } from '$lib/icons/utils';
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	let showSheet = $state(false);
+	let activeChip = $state<'all' | 'makkiyah' | 'madaniyah'>('all');
+	let bannerDismissed = $state(false);
+	let demoText = $state('');
+	let demoTextarea = $state('');
+	let demoEmail = $state('not-an-email');
+	let demoCheckbox = $state(true);
+	let demoCheckboxB = $state(false);
+	let demoRadio = $state<'id' | 'en' | 'ar'>('id');
+
+	function showToast(type: 'info' | 'success' | 'error' | 'warn') {
+		const messageById = {
+			info: isEnglish ? 'This is an info message' : 'Ini pesan informasi',
+			success: isEnglish ? 'Saved successfully' : 'Berhasil disimpan',
+			warn: isEnglish ? 'Please double-check your input' : 'Mohon periksa kembali masukan kamu',
+			error: isEnglish ? 'Something went wrong' : 'Terjadi kesalahan'
+		};
+		toast.show({ message: messageById[type], type });
+	}
+
+	const iconSizes: IconSize[] = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+	const iconList = [
+		{ name: 'Bookmark', Comp: BookmarkIcon },
+		{ name: 'BookmarkSolid', Comp: BookmarkSolidIcon },
+		{ name: 'Heart', Comp: HeartIcon },
+		{ name: 'HeartSolid', Comp: HeartSolidIcon },
+		{ name: 'Share', Comp: ShareIcon },
+		{ name: 'Copy', Comp: CopyIcon },
+		{ name: 'Play', Comp: PlayIcon },
+		{ name: 'Pause', Comp: PauseIcon },
+		{ name: 'Home', Comp: HomeIcon },
+		{ name: 'Setting', Comp: SettingIcon },
+		{ name: 'Search', Comp: SearchIcon },
+		{ name: 'XMark', Comp: XMarkIcon },
+		{ name: 'CheckCircle', Comp: CheckCircleIcon },
+		{ name: 'Fire', Comp: FireIcon },
+		{ name: 'InformationCircle', Comp: InformationCircleIcon },
+		{ name: 'ExclamationTriangle', Comp: ExclamationTriangleIcon },
+		{ name: 'ArrowLeft', Comp: ArrowLeftIcon },
+		{ name: 'ArrowRight', Comp: ArrowRightIcon },
+		{ name: 'ChevronUp', Comp: ChevronUpIcon },
+		{ name: 'ChevronDown', Comp: ChevronDownIcon }
+	];
+
+	const META_TITLE = $derived(
+		`${isEnglish ? 'Design System' : 'Sistem Desain'} | ${TITLE_CONSTANTS.TITLE_META}`
+	);
+	const META_DESC = $derived(
+		isEnglish
+			? 'Documentation of all shareable UI components used across Baca-Quran.id — buttons, badges, chips, bottom sheets, icons and more.'
+			: 'Dokumentasi seluruh komponen UI yang dipakai bersama di Baca-Quran.id — tombol, badge, chip, bottom sheet, ikon, dan lainnya.'
+	);
+
+	const tocItems = $derived([
+		{ id: 'colors', label: $t('designSystem.section.colors') },
+		{ id: 'typography', label: $t('designSystem.section.typography') },
+		{ id: 'buttons', label: $t('designSystem.section.buttons') },
+		{ id: 'badges', label: $t('designSystem.section.badges') },
+		{ id: 'chips', label: $t('designSystem.section.chips') },
+		{ id: 'banners', label: $t('designSystem.section.banners') },
+		{ id: 'forms', label: $t('designSystem.section.forms') },
+		{ id: 'collapsible', label: $t('designSystem.section.collapsible') },
+		{ id: 'bottom-sheet', label: $t('designSystem.section.bottomSheet') },
+		{ id: 'toasts', label: $t('designSystem.section.toasts') },
+		{ id: 'breadcrumb', label: $t('designSystem.section.breadcrumb') },
+		{ id: 'cards', label: $t('designSystem.section.cards') },
+		{ id: 'icons', label: $t('designSystem.section.icons') }
+	]);
+</script>
+
+<svelte:head>
+	<MetaTag title={META_TITLE} desc={META_DESC} url={`${TITLE_CONSTANTS.PATH}design-system/`} />
+</svelte:head>
+
+<div class="flex gap-2 px-4 mb-4">
+	<h1 class="text-3xl font-bold">
+		🎨 {isEnglish ? 'Design System' : 'Sistem Desain'}
+	</h1>
+</div>
+
+<div class="px-4 mb-4">
+	<Breadcrumb
+		items={[
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
+			{ text: $t('navigation.designSystem'), href: '/design-system/' }
+		]}
+	/>
+</div>
+
+<div class="px-4 flex flex-col gap-8 mb-8">
+	<p class="text-sm opacity-75">
+		{isEnglish
+			? 'A living reference for the shareable UI primitives used across the app. Each section shows what the component looks like, how it can vary, and a hint of how to use it.'
+			: 'Referensi hidup untuk komponen UI yang dipakai bersama di seluruh aplikasi. Setiap bagian menampilkan tampilan komponen, ragam variannya, dan petunjuk pemakaiannya.'}
+	</p>
+
+	<!-- TABLE OF CONTENTS -->
+	<Collapsible title={$t('designSystem.toc.title')} id="design-system-toc">
+		<nav aria-label={$t('designSystem.toc.title')}>
+			<ul class="grid grid-cols-1 sm:grid-cols-2 gap-1">
+				{#each tocItems as item (item.id)}
+					<li>
+						<a
+							href={`#${item.id}`}
+							class="block px-2 py-1 rounded text-sm hover:bg-secondary focus:bg-secondary"
+						>
+							{item.label}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	</Collapsible>
+
+	<!-- COLOR TOKENS -->
+	<section id="colors" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.colors')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.colorsDesc')}</p>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.colors.semanticTokens')}</h3>
+		<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+			<CardShadow class="flex flex-col gap-1">
+				<div class="w-full h-12 rounded bg-primary border border-foreground/20"></div>
+				<code class="text-xs">bg-primary</code>
+			</CardShadow>
+			<CardShadow class="flex flex-col gap-1">
+				<div class="w-full h-12 rounded bg-secondary border border-foreground/20"></div>
+				<code class="text-xs">bg-secondary</code>
+			</CardShadow>
+			<CardShadow class="flex flex-col gap-1">
+				<div
+					class="w-full h-12 rounded border border-foreground/20 flex items-center justify-center"
+				>
+					<span class="text-foreground">Aa</span>
+				</div>
+				<code class="text-xs">text-foreground</code>
+			</CardShadow>
+			<CardShadow class="flex flex-col gap-1">
+				<div
+					class="w-full h-12 rounded border border-foreground/20 flex items-center justify-center"
+				>
+					<span class="text-foreground-secondary">Aa</span>
+				</div>
+				<code class="text-xs">text-foreground-secondary</code>
+			</CardShadow>
+		</div>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.colors.themePalette')}</h3>
+		<p class="text-xs opacity-75">{$t('designSystem.colors.themePaletteDesc')}</p>
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+			{#each THEMES as theme (theme.name)}
+				<CardShadow class="flex flex-col gap-2">
+					<div class="flex items-center justify-between">
+						<code class="text-sm font-semibold">{theme.name}</code>
+						<span
+							class="inline-block w-5 h-5 rounded-full border"
+							style={`background:${theme.bg};border-color:${theme.border}`}
+							aria-hidden="true"
+						></span>
+					</div>
+					<div class="flex gap-1">
+						<div
+							class="flex-1 h-8 rounded flex items-center justify-center text-[10px] border border-foreground/20"
+							style={`background:${theme.bg};color:${theme.border}`}
+						>
+							bg
+						</div>
+						<div
+							class="flex-1 h-8 rounded flex items-center justify-center text-[10px] border border-foreground/20"
+							style={`background:${theme.border};color:${theme.bg}`}
+						>
+							fg
+						</div>
+					</div>
+					<div class="flex justify-between text-[10px] opacity-75">
+						<code>{theme.bg}</code>
+						<code>{theme.border}</code>
+					</div>
+				</CardShadow>
+			{/each}
+		</div>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.colors.utilityPalette')}</h3>
+		<p class="text-xs opacity-75">{$t('designSystem.colors.utilityPaletteDesc')}</p>
+		<div class="grid grid-cols-3 sm:grid-cols-6 gap-2">
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-blue-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-blue-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-blue-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">blue</code>
+			</div>
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-green-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-green-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-green-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">green</code>
+			</div>
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-orange-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-orange-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-orange-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">orange</code>
+			</div>
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-red-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-red-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-red-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">red</code>
+			</div>
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-purple-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-purple-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-purple-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">purple</code>
+			</div>
+			<div class="flex flex-col gap-1">
+				<div class="h-10 rounded bg-gray-100" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-gray-500" aria-hidden="true"></div>
+				<div class="h-10 rounded bg-gray-700" aria-hidden="true"></div>
+				<code class="text-[10px] text-center">gray</code>
+			</div>
+		</div>
+	</section>
+
+	<!-- TYPOGRAPHY -->
+	<section id="typography" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.typography')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.typographyDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-2">
+			<div class="text-3xl font-bold">Heading 1 — text-3xl font-bold</div>
+			<div class="text-2xl font-bold">Heading 2 — text-2xl font-bold</div>
+			<div class="text-xl font-bold">Heading 3 — text-xl font-bold</div>
+			<div class="text-md font-semibold">Body strong — text-md font-semibold</div>
+			<div class="text-sm">Body — text-sm</div>
+			<div class="text-xs opacity-75">Caption — text-xs opacity-75</div>
+			<div class="font-arabic text-2xl mt-2">بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ</div>
+			<code class="text-xs">.font-arabic — lpmq font</code>
+		</CardShadow>
+	</section>
+
+	<!-- BUTTONS -->
+	<section id="buttons" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.buttons')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.buttonsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-4">
+			<div class="flex flex-wrap items-center gap-3">
+				<Button onClick={() => showToast('info')}>
+					<span>{$t('designSystem.buttons.filled')}</span>
+				</Button>
+				<Button variant="subtle" onClick={() => showToast('info')}>
+					<span>{$t('designSystem.buttons.subtle')}</span>
+				</Button>
+				<Button variant="outline" onClick={() => showToast('info')}>
+					<span>{$t('designSystem.buttons.outline')}</span>
+				</Button>
+			</div>
+
+			<div class="flex flex-wrap items-center gap-3">
+				<Button onClick={() => showToast('success')} ariaLabel="Bookmark">
+					<BookmarkIcon size="sm" />
+					<span>{$t('designSystem.buttons.withIcon')}</span>
+				</Button>
+				<Button variant="subtle" onClick={() => showToast('success')} ariaLabel="Share">
+					<ShareIcon size="sm" />
+				</Button>
+				<Button variant="outline" onClick={() => showToast('success')} ariaLabel="Play">
+					<PlayIcon size="sm" />
+				</Button>
+			</div>
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Button variant="filled | subtle | outline" onClick={fn}>...</Button>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- BADGES -->
+	<section id="badges" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.badges')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.badgesDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<div class="flex flex-wrap items-center gap-3">
+				<Badge>Makkiyah</Badge>
+				<Badge color="orange">Madaniyah</Badge>
+				<Badge>
+					<CheckCircleIcon size="xs" />
+					{isEnglish ? 'Verified' : 'Terverifikasi'}
+				</Badge>
+			</div>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Badge color="green | orange">label</Badge>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- CHIPS / PILLS -->
+	<section id="chips" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.chips')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.chipsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-4">
+			<div class="flex flex-wrap items-center gap-2">
+				<Chip>Neutral</Chip>
+				<Chip color="blue">Blue</Chip>
+				<Chip color="green">Green</Chip>
+				<Chip color="orange">Orange</Chip>
+				<Chip color="red">Red</Chip>
+				<Chip color="purple">Purple</Chip>
+			</div>
+
+			<div class="flex flex-wrap items-center gap-2">
+				<Chip color="blue" size="sm">size=sm</Chip>
+				<Chip color="blue" size="md">size=md</Chip>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<p class="text-xs opacity-75">{$t('designSystem.chips.interactive')}</p>
+				<div class="flex flex-wrap items-center gap-2">
+					<Chip color="blue" active={activeChip === 'all'} onClick={() => (activeChip = 'all')}>
+						{isEnglish ? 'All' : 'Semua'}
+					</Chip>
+					<Chip
+						color="green"
+						active={activeChip === 'makkiyah'}
+						onClick={() => (activeChip = 'makkiyah')}
+					>
+						Makkiyah
+					</Chip>
+					<Chip
+						color="orange"
+						active={activeChip === 'madaniyah'}
+						onClick={() => (activeChip = 'madaniyah')}
+					>
+						Madaniyah
+					</Chip>
+				</div>
+				<p class="text-xs opacity-75">
+					{isEnglish ? 'Active: ' : 'Aktif: '}<code>{activeChip}</code>
+				</p>
+			</div>
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Chip color="blue" size="md" active onClick={fn}>label</Chip>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- BANNERS / ALERTS -->
+	<section id="banners" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.banners')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.bannersDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<Banner type="info" title={$t('designSystem.banner.infoTitle')}>
+				{$t('designSystem.banner.infoBody')}
+			</Banner>
+			<Banner type="success" title={$t('designSystem.banner.successTitle')}>
+				{$t('designSystem.banner.successBody')}
+			</Banner>
+			<Banner type="warn" title={$t('designSystem.banner.warnTitle')}>
+				{$t('designSystem.banner.warnBody')}
+			</Banner>
+			<Banner type="error" title={$t('designSystem.banner.errorTitle')}>
+				{$t('designSystem.banner.errorBody')}
+			</Banner>
+
+			{#if !bannerDismissed}
+				<Banner
+					type="info"
+					dismissible
+					onDismiss={() => (bannerDismissed = true)}
+					ariaLabelClose={$t('common.close')}
+				>
+					{$t('designSystem.banner.dismissibleBody')}
+				</Banner>
+			{:else}
+				<p class="text-xs opacity-75">
+					{$t('designSystem.banner.dismissedHint')}
+					<button
+						type="button"
+						class="underline cursor-pointer"
+						onclick={() => (bannerDismissed = false)}>{$t('designSystem.banner.restore')}</button
+					>
+				</p>
+			{/if}
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Banner type="info | success | warn | error" title="..." dismissible>body</Banner>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- FORM CONTROLS -->
+	<section id="forms" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.forms')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.formsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-4">
+			<h3 class="font-semibold">Input</h3>
+			<Input
+				label={$t('designSystem.forms.textLabel')}
+				placeholder={$t('designSystem.forms.textPlaceholder')}
+				hint={$t('designSystem.forms.textHint')}
+				bind:value={demoText}
+			/>
+			<Input
+				type="email"
+				label={$t('designSystem.forms.emailLabel')}
+				placeholder="you@example.com"
+				bind:value={demoEmail}
+				error={demoEmail && !demoEmail.includes('@') ? $t('designSystem.forms.emailError') : ''}
+			/>
+			<Input label={$t('designSystem.forms.disabledLabel')} value="readonly" disabled />
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Input label="..." bind:value error="..." hint="..." />'}</code
+				></pre>
+		</CardShadow>
+
+		<CardShadow class="flex flex-col gap-4">
+			<h3 class="font-semibold">Textarea</h3>
+			<Textarea
+				label={$t('designSystem.forms.textareaLabel')}
+				placeholder={$t('designSystem.forms.textareaPlaceholder')}
+				hint={$t('designSystem.forms.textareaHint')}
+				rows={3}
+				bind:value={demoTextarea}
+			/>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Textarea label="..." rows={4} bind:value />'}</code
+				></pre>
+		</CardShadow>
+
+		<CardShadow class="flex flex-col gap-3">
+			<h3 class="font-semibold">Checkbox</h3>
+			<Checkbox
+				label={$t('designSystem.forms.checkboxA')}
+				hint={$t('designSystem.forms.checkboxAHint')}
+				bind:checked={demoCheckbox}
+			/>
+			<Checkbox label={$t('designSystem.forms.checkboxB')} bind:checked={demoCheckboxB} />
+			<Checkbox label={$t('designSystem.forms.checkboxDisabled')} checked disabled />
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Checkbox label="..." bind:checked />'}</code
+				></pre>
+		</CardShadow>
+
+		<CardShadow class="flex flex-col gap-3">
+			<h3 class="font-semibold">Radio</h3>
+			<div class="flex flex-col gap-2">
+				<Radio
+					name="demo-lang"
+					value="id"
+					label={$t('designSystem.forms.radioId')}
+					bind:group={demoRadio}
+				/>
+				<Radio
+					name="demo-lang"
+					value="en"
+					label={$t('designSystem.forms.radioEn')}
+					bind:group={demoRadio}
+				/>
+				<Radio
+					name="demo-lang"
+					value="ar"
+					label={$t('designSystem.forms.radioAr')}
+					hint={$t('designSystem.forms.radioArHint')}
+					bind:group={demoRadio}
+				/>
+			</div>
+			<p class="text-xs opacity-75">
+				{$t('designSystem.forms.selected')} <code>{demoRadio}</code>
+			</p>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Radio name="..." value="..." label="..." bind:group />'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- COLLAPSIBLE -->
+	<section id="collapsible" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.collapsible')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.collapsibleDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<Collapsible title={$t('designSystem.collapsible.what')}>
+				<p class="text-sm">
+					{isEnglish
+						? 'A collapsible reveals more detail on demand, keeping the page scannable.'
+						: 'Komponen collapsible menyembunyikan detail sampai dibutuhkan agar halaman tetap mudah dipindai.'}
+				</p>
+			</Collapsible>
+			<Collapsible title={$t('designSystem.collapsible.when')} open>
+				<ul class="list-disc pl-6 text-sm flex flex-col gap-1">
+					<li>{isEnglish ? 'FAQs and long help text' : 'FAQ dan teks bantuan panjang'}</li>
+					<li>{isEnglish ? 'Tafsir or footnotes' : 'Tafsir atau catatan kaki'}</li>
+					<li>{isEnglish ? 'Optional settings groups' : 'Grup pengaturan opsional'}</li>
+				</ul>
+			</Collapsible>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<Collapsible title="..." open>content</Collapsible>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- BOTTOM SHEET -->
+	<section id="bottom-sheet" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.bottomSheet')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.bottomSheetDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<div>
+				<Button onClick={() => (showSheet = true)}>
+					<span>{$t('designSystem.bottomSheet.open')}</span>
+				</Button>
+			</div>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<BottomSheet show={open} title="..." onClose={fn}>content</BottomSheet>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- TOASTS -->
+	<section id="toasts" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.toasts')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.toastsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<div class="flex flex-wrap gap-3">
+				<Button onClick={() => showToast('info')}>
+					<InformationCircleIcon size="sm" /> info
+				</Button>
+				<Button onClick={() => showToast('success')}>
+					<CheckCircleIcon size="sm" /> success
+				</Button>
+				<Button onClick={() => showToast('warn')}>
+					<ExclamationTriangleIcon size="sm" /> warn
+				</Button>
+				<Button onClick={() => showToast('error')}>
+					<FireIcon size="sm" /> error
+				</Button>
+			</div>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{"toast.show({ message: '...', type: 'info | success | warn | error' })"}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- BREADCRUMB -->
+	<section id="breadcrumb" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.breadcrumb')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.breadcrumbDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-3">
+			<Breadcrumb
+				items={[
+					{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
+					{ text: $t('navigation.allSurah'), href: '/all-surah/' },
+					{ text: 'Al-Fatihah', href: '/surah/1/' }
+				]}
+			/>
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{"<Breadcrumb items={[{ text: '...', href: '/' }]} />"}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- CARDS -->
+	<section id="cards" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.cards')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.cardsDesc')}</p>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.cards.variants')}</h3>
+		<div class="grid sm:grid-cols-3 gap-3">
+			<Card variant="filled" title="filled">
+				<p class="text-sm opacity-75">{$t('designSystem.cards.filledDesc')}</p>
+			</Card>
+			<Card variant="outline" title="outline">
+				<p class="text-sm opacity-75">{$t('designSystem.cards.outlineDesc')}</p>
+			</Card>
+			<Card variant="elevated" title="elevated">
+				<p class="text-sm opacity-75">{$t('designSystem.cards.elevatedDesc')}</p>
+			</Card>
+		</div>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.cards.composed')}</h3>
+		<div class="grid sm:grid-cols-2 gap-3">
+			<Card variant="filled" padding="md">
+				{#snippet header()}
+					<div class="flex items-center gap-2">
+						<HeartSolidIcon size="sm" />
+						<h3 class="font-semibold">{$t('designSystem.cards.withHeaderTitle')}</h3>
+					</div>
+				{/snippet}
+				<p class="text-sm">{$t('designSystem.cards.withHeaderBody')}</p>
+				{#snippet footer()}
+					<div class="flex justify-end gap-2">
+						<Button variant="subtle" onClick={() => showToast('info')}>
+							<span class="text-xs">{$t('common.cancel')}</span>
+						</Button>
+						<Button onClick={() => showToast('success')}>
+							<span class="text-xs">{$t('common.save')}</span>
+						</Button>
+					</div>
+				{/snippet}
+			</Card>
+
+			<Card
+				as="a"
+				href="/design-system/"
+				variant="elevated"
+				title={$t('designSystem.cards.linkTitle')}
+				subtitle={$t('designSystem.cards.linkSubtitle')}
+			>
+				<p class="text-sm opacity-75">{$t('designSystem.cards.linkBody')}</p>
+			</Card>
+		</div>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.cards.padding')}</h3>
+		<div class="grid sm:grid-cols-4 gap-3">
+			<Card variant="outline" padding="none">
+				<div class="text-xs text-center">padding=none</div>
+			</Card>
+			<Card variant="outline" padding="sm">
+				<div class="text-xs text-center">padding=sm</div>
+			</Card>
+			<Card variant="outline" padding="md">
+				<div class="text-xs text-center">padding=md</div>
+			</Card>
+			<Card variant="outline" padding="lg">
+				<div class="text-xs text-center">padding=lg</div>
+			</Card>
+		</div>
+
+		<h3 class="text-md font-semibold mt-2">{$t('designSystem.cards.legacy')}</h3>
+		<p class="text-xs opacity-75">{$t('designSystem.cards.legacyDesc')}</p>
+		<div class="grid sm:grid-cols-2 gap-3">
+			<CardShadow>
+				<h3 class="font-semibold mb-1">CardShadow</h3>
+				<p class="text-sm opacity-75">
+					{isEnglish
+						? 'Generic content container with secondary background and shadow.'
+						: 'Wadah konten generik dengan latar sekunder dan bayangan.'}
+				</p>
+			</CardShadow>
+			<CardShadow _as="a" href="/design-system/">
+				<h3 class="font-semibold mb-1">CardShadow (link)</h3>
+				<p class="text-sm opacity-75">
+					{isEnglish
+						? 'Render as anchor with the same look.'
+						: 'Render sebagai anchor dengan tampilan yang sama.'}
+				</p>
+			</CardShadow>
+		</div>
+
+		<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+				>{'<Card variant="filled | outline | elevated" padding="none | sm | md | lg" title="..." subtitle="...">\n  body\n  {#snippet header()}...{/snippet}\n  {#snippet footer()}...{/snippet}\n</Card>'}</code
+			></pre>
+	</section>
+
+	<!-- ICONS -->
+	<section id="icons" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{$t('designSystem.section.icons')}</h2>
+		<p class="text-sm opacity-75">{$t('designSystem.section.iconsDesc')}</p>
+
+		<CardShadow class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.icons.sizes')}</h3>
+				<div class="flex items-end gap-4">
+					{#each iconSizes as size (size)}
+						<div class="flex flex-col items-center gap-1">
+							<BookmarkIcon {size} />
+							<code class="text-xs">{size}</code>
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold">{$t('designSystem.icons.gallery')}</h3>
+				<div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
+					{#each iconList as icon (icon.name)}
+						{@const Icon = icon.Comp}
+						<div
+							class="flex flex-col items-center gap-1 p-3 rounded-md bg-primary border border-foreground/10"
+						>
+							<Icon size="md" />
+							<code class="text-[10px] text-center break-all">{icon.name}</code>
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{'<BookmarkIcon size="xs | sm | md | lg | xl" />'}</code
+				></pre>
+		</CardShadow>
+	</section>
+</div>
+
+<BottomSheet
+	show={showSheet}
+	title={$t('designSystem.bottomSheet.demoTitle')}
+	id="design-system-demo-sheet"
+	onClose={() => (showSheet = false)}
+>
+	<div class="p-4 flex flex-col gap-2">
+		<p class="text-sm">
+			{isEnglish
+				? 'This sheet slides up from the bottom. It is used across the app for share dialogs, tafsir details, and other contextual actions.'
+				: 'Sheet ini muncul dari bawah. Dipakai di seluruh aplikasi untuk dialog berbagi, detail tafsir, dan aksi kontekstual lainnya.'}
+		</p>
+		<div class="flex gap-2">
+			<Badge>demo</Badge>
+			<Chip color="blue" size="sm">bottom-sheet</Chip>
+		</div>
+	</div>
+</BottomSheet>

--- a/src/routes/tasbih/+page.svelte
+++ b/src/routes/tasbih/+page.svelte
@@ -99,7 +99,7 @@
 	</div>
 	<div class="flex justify-center items-center gap-4">
 		<Button
-			variant="filled"
+			variant="solid"
 			class={`px-4 rounded-lg border-2 border-secondary bg-secondary`}
 			onClick={toggleSound}
 		>
@@ -111,7 +111,7 @@
 		</Button>
 		<div class="flex justify-center items-center">
 			<Button
-				variant="filled"
+				variant="solid"
 				class={`px-4 rounded-l-lg rounded-r-none border-2 border-secondary ${target === 11 ? 'bg-secondary' : ''}`}
 				onClick={() => {
 					handleSetTarget(11);
@@ -120,7 +120,7 @@
 				<span class="text-xl">11</span>
 			</Button>
 			<Button
-				variant="filled"
+				variant="solid"
 				class={`px-4 rounded-none border-t-2 border-b-2 border-secondary ${target === 33 ? 'bg-secondary' : ''}`}
 				onClick={() => {
 					handleSetTarget(33);
@@ -129,7 +129,7 @@
 				<span class="text-xl">33</span>
 			</Button>
 			<Button
-				variant="filled"
+				variant="solid"
 				class={`px-4 rounded-r-lg rounded-l-none border-2 border-secondary ${target === 99 ? 'bg-secondary' : ''}`}
 				onClick={() => {
 					handleSetTarget(99);

--- a/src/routes/wirid/+page.svelte
+++ b/src/routes/wirid/+page.svelte
@@ -27,13 +27,13 @@
 			<div class="relative">
 				{#if item.arabic.indexOf('Membaca') >= 0}
 					<div class="absolute bottom-0 right-0">
-						<Badge color="green">
+						<Badge color="success">
 							{`${item.id}x`}
 						</Badge>
 					</div>
 				{:else}
 					<div class="absolute bottom-0 left-0">
-						<Badge color="green">
+						<Badge color="success">
 							{`${item.id}x`}
 						</Badge>
 					</div>


### PR DESCRIPTION
## Summary

Adds a living design-system page at `/design-system/` that documents every shareable UI primitive, and redesigns the Badge/Button APIs around a consistent variant × color × size matrix so the same vocabulary works across components (and matches what toasts/banners already speak).

### New page — `/design-system/`
- Collapsible **Table of Contents** at the top for fast jumps.
- **Colors & tokens**: semantic tokens (`bg-primary`, `bg-secondary`, `text-foreground`, `text-foreground-secondary`), per-theme palette swatches for all 9 themes, and Tailwind utility ramps.
- **Typography**: text scale + Arabic `lpmq` sample.
- **Buttons**: full variant × color matrix, sizes (sm/md/lg), with-icon, disabled.
- **Icon Buttons**: sizes (xs/sm/md/lg), variants (ghost/subtle/outline/solid), rounded md/full, disabled.
- **Badges**: full variant × color matrix, sizes, with-icon.
- **Chips / Pills**: 6 colors × 2 sizes + interactive filter demo.
- **Banner / Alert**: info/success/warn/error + dismissible.
- **Form Controls**: Input (sizes, error, hint, disabled), Textarea (sizes), Checkbox, Radio.
- **Collapsible**, **Bottom Sheet**, **Toasts**, **Breadcrumb**.
- **Cards**: new `Card` (filled/outline/elevated, padding scale, header+footer composition) + legacy `CardShadow`.
- **Icons**: 5 sizes + 20-icon gallery.

### New components (under `src/lib/ui/`)
`Chip`, `Collapsible`, `Banner`, `Card`, `Input`, `Textarea`, `Checkbox`, `Radio`, `IconButton`. Plus a new `SwatchIcon` for the drawer entry.

### Redesigned components
- **Badge**: `variant: solid | subtle | outline` × `color: primary | secondary | success | warning | danger` × `size: sm | md | lg`. Drops legacy `green`/`orange` color names — existing callers (`SurahCard`, `wirid`, `asmaul-husna`) migrated to `success`/`warning`.
- **Button**: same matrix, plus `size`, `disabled`, and proper `data-*` attribute forwarding (which was previously silently dropped). Variant `filled` renamed to `solid` — `tasbih` page caller migrated.

### Wiring
- Drawer link added (uses the new `SwatchIcon`).
- Route registered in `scripts/routes.js` so prerender + sitemap include it.
- `navigation.designSystem` + `designSystem.*` keys added to both `id.json` and `en.json`.

## Test plan

- [ ] `pnpm check` — 0 errors
- [ ] `pnpm lint` — clean
- [ ] `pnpm build:ci` — builds successfully and `build/design-system/index.html` exists
- [ ] `build/sitemaps/static.xml` includes `/design-system/`
- [ ] Visit `/design-system/` in the dev server: every section renders, TOC anchors scroll to sections
- [ ] Toggle language id ↔ en — every string switches
- [ ] Cycle every theme — text stays readable, palette swatches reflect the active theme
- [ ] Trigger every toast type, open/close the bottom sheet, dismiss/restore the banner, toggle the collapsible
- [ ] Verify existing pages still render correctly: `/` (SurahCard badge color), `/wirid/`, `/asmaul-husna/`, `/tasbih/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTyS6KjjohGJzGsSCzjbwf)_