### PR TITLE
feat: redesign pencatat-ibadah with sunnah prayers, streak, and calendar recap

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -137,7 +137,17 @@
 		"viewRecap": "View Recap",
 		"logRecap": "Prayer Log Recap",
 		"date": "Date",
-		"noRecapData": "No recap data for {{month}} yet"
+		"noRecapData": "No recap data for {{month}} yet",
+		"fardPrayer": "Obligatory Prayers",
+		"sunnahPrayer": "Sunnah Prayers",
+		"daysTracked": "Days Tracked",
+		"perfectDays": "Perfect Days",
+		"tapForDetail": "Tap a date to view details",
+		"noDataForDay": "No data for this date yet",
+		"calendarLegend": "Legend",
+		"prevDay": "Previous Day",
+		"nextDay": "Next Day",
+		"streak": "Streak"
 	},
 	"prayerSchedule": {
 		"locationSuccess": "Managed to get the latest location!",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -137,7 +137,17 @@
 		"viewRecap": "Lihat Rekap",
 		"logRecap": "Rekap Pencatat Ibadah",
 		"date": "Tanggal",
-		"noRecapData": "Belum ada data rekap untuk bulan {{month}}"
+		"noRecapData": "Belum ada data rekap untuk bulan {{month}}",
+		"fardPrayer": "Sholat Wajib",
+		"sunnahPrayer": "Sholat Sunnah",
+		"daysTracked": "Hari Dicatat",
+		"perfectDays": "Hari Sempurna",
+		"tapForDetail": "Ketuk tanggal untuk melihat detail",
+		"noDataForDay": "Belum ada data untuk tanggal ini",
+		"calendarLegend": "Keterangan",
+		"prevDay": "Hari Sebelumnya",
+		"nextDay": "Hari Berikutnya",
+		"streak": "Streak"
 	},
 	"prayerSchedule": {
 		"locationSuccess": "Berhasil mendapatkan lokasi teranyar!",

--- a/src/routes/pencatat-ibadah/+page.svelte
+++ b/src/routes/pencatat-ibadah/+page.svelte
@@ -9,128 +9,99 @@
 		TITLE_CONSTANTS
 	} from '$lib/constants';
 	import { formatDate, getCurrentDate, getDayInMonth } from '$lib/utils/date';
-	import { range } from '$lib/utils/array';
 	import type { PrayerKey } from '$lib/types';
-	import CardShadow from '$lib/CardShadow.svelte';
-	import {
-		logPrayer,
-		type LogPrayerItemKey,
-		type LogPrayerItemValue,
-		type LogPrayerValue
-	} from '$store';
+	import { logPrayer, type LogPrayerItemKey, type LogPrayerItemValue } from '$store';
 	import { onMount } from 'svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import { t } from '$lib/translations/store';
 
-	let defaultItem = {
-		'1': 0,
-		'2': 0,
-		'3': 0,
-		'4': 0,
-		'5': 0
-	};
+	const FARD_PRAYERS: Array<{ key: PrayerKey; title: string; id: LogPrayerItemKey; emoji: string }> =
+		[
+			{ key: 'Fajr', title: 'Subuh', id: '1', emoji: '🌅' },
+			{ key: 'Dhuhr', title: 'Dzuhur', id: '2', emoji: '☀️' },
+			{ key: 'Asr', title: 'Ashar', id: '3', emoji: '🌤️' },
+			{ key: 'Maghrib', title: 'Maghrib', id: '4', emoji: '🌆' },
+			{ key: 'Isha', title: 'Isya', id: '5', emoji: '🌙' }
+		];
 
-	let dayInMonth = getDayInMonth(new Date().toISOString());
-	let dayRanges = range(1, dayInMonth);
-
-	let selectedDate = $state(getCurrentDate());
-	let selectedDateFormatted = $derived.by(() => {
-		const nDate = new Date();
-		nDate.setDate(selectedDate);
-		const res = formatDate(nDate.toISOString(), 'dddd, DD MMMM YYYY');
-		return res;
-	});
-	let selectedYYYYMMDD = $derived.by(() => {
-		const nDate = new Date();
-		nDate.setDate(selectedDate);
-		const res = formatDate(nDate.toISOString(), 'YYYYMMDD');
-		return res;
-	});
-
-	const PRAYER_LIST: Array<{
-		key: PrayerKey;
-		title: string;
-		id: LogPrayerItemKey;
-	}> = [
-		{
-			key: 'Fajr',
-			title: 'Subuh',
-			id: '1'
-		},
-		{
-			key: 'Dhuhr',
-			title: 'Dzuhur',
-			id: '2'
-		},
-		{
-			key: 'Asr',
-			title: 'Ashar',
-			id: '3'
-		},
-		{
-			key: 'Maghrib',
-			title: 'Maghrib',
-			id: '4'
-		},
-		{
-			key: 'Isha',
-			title: 'Isya',
-			id: '5'
-		}
+	const SUNNAH_PRAYERS: Array<{ title: string; id: LogPrayerItemKey; emoji: string }> = [
+		{ title: 'Qabliyah Subuh', id: '6', emoji: '🌅' },
+		{ title: 'Qabliyah Dzuhur', id: '7', emoji: '☀️' },
+		{ title: "Ba'diyah Dzuhur", id: '8', emoji: '✨' },
+		{ title: "Ba'diyah Maghrib", id: '9', emoji: '🌆' },
+		{ title: "Ba'diyah Isya", id: '10', emoji: '🌙' },
+		{ title: 'Dhuha', id: '11', emoji: '🌄' },
+		{ title: 'Tahajjud', id: '12', emoji: '🌌' }
 	];
 
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
-	let handleCheckUncheck = (e) => {
-		const id = e.target.value.toString() as LogPrayerItemKey;
-		const isChecked = e.target.checked as boolean;
+	let dayInMonth = getDayInMonth(new Date().toISOString());
+	let selectedDate = $state(getCurrentDate());
+	let isToday = $derived(selectedDate === getCurrentDate());
 
+	let selectedYYYYMMDD = $derived.by(() => {
+		const d = new Date();
+		d.setDate(selectedDate);
+		return formatDate(d.toISOString(), 'YYYYMMDD');
+	});
+
+	let selectedDateFormatted = $derived.by(() => {
+		const d = new Date();
+		d.setDate(selectedDate);
+		return formatDate(d.toISOString(), 'dddd, DD MMMM YYYY');
+	});
+
+	let fardCompleted = $derived.by(() => {
+		const dayData = $logPrayer[selectedYYYYMMDD];
+		if (!dayData) return 0;
+		return FARD_PRAYERS.filter((p) => dayData[p.id] === 1).length;
+	});
+
+	let sunnahCompleted = $derived.by(() => {
+		const dayData = $logPrayer[selectedYYYYMMDD];
+		if (!dayData) return 0;
+		return SUNNAH_PRAYERS.filter((p) => dayData[p.id] === 1).length;
+	});
+
+	let currentStreak = $derived.by(() => {
+		const base = new Date();
+		const todayFardDone = FARD_PRAYERS.every(
+			(p) => $logPrayer[formatDate(base.toISOString(), 'YYYYMMDD')]?.[p.id] === 1
+		);
+		let count = 0;
+		for (let i = todayFardDone ? 0 : 1; i < 366; i++) {
+			const d = new Date(base);
+			d.setDate(base.getDate() - i);
+			const key = formatDate(d.toISOString(), 'YYYYMMDD');
+			const dayData = $logPrayer[key];
+			if (!dayData || !FARD_PRAYERS.every((p) => dayData[p.id] === 1)) break;
+			count++;
+		}
+		return count;
+	});
+
+	function togglePrayer(id: LogPrayerItemKey) {
 		logPrayer.update((val) => {
-			const newItem = {
-				[id]: isChecked ? 1 : (0 as LogPrayerItemValue)
-			} as LogPrayerValue;
-
-			if (val) {
-				if (val[selectedYYYYMMDD]) {
-					val[selectedYYYYMMDD] = {
-						...val[selectedYYYYMMDD],
-						...newItem
-					};
-				} else {
-					val[selectedYYYYMMDD] = {
-						...defaultItem,
-						...newItem
-					};
+			const currentDay = val[selectedYYYYMMDD] || {};
+			const updated = {
+				...val,
+				[selectedYYYYMMDD]: {
+					...currentDay,
+					[id]: (currentDay[id] === 1 ? 0 : 1) as LogPrayerItemValue
 				}
-			} else {
-				val = {
-					[selectedYYYYMMDD]: {
-						...defaultItem,
-						...newItem
-					}
-				};
-			}
-
-			localStorage.setItem(CONSTANTS.STORAGE_KEY.LOG_PRAYER, JSON.stringify(val));
-			return val;
+			};
+			localStorage.setItem(CONSTANTS.STORAGE_KEY.LOG_PRAYER, JSON.stringify(updated));
+			return updated;
 		});
-	};
+	}
 
 	onMount(() => {
 		if (window.location.hash) {
-			const hash = window.location.hash;
-			const day = hash.replace('#day-', '');
-			selectedDate = parseInt(day);
+			const day = parseInt(window.location.hash.replace('#day-', ''));
+			if (!isNaN(day) && day >= 1 && day <= dayInMonth) {
+				selectedDate = day;
+			}
 		}
-
-		const timeout = setTimeout(() => {
-			window.location.hash = `day-${selectedDate}`;
-		}, 1000);
-
-		return () => {
-			clearTimeout(timeout);
-		};
 	});
 </script>
 
@@ -143,9 +114,7 @@
 </svelte:head>
 
 <div class="flex gap-2 px-4 mb-4">
-	<h1 class="text-3xl font-bold">
-		⏺️ {$t('navigation.worshipTracker')}
-	</h1>
+	<h1 class="text-3xl font-bold">⏺️ {$t('navigation.worshipTracker')}</h1>
 </div>
 
 <div class="px-4 mb-4">
@@ -159,53 +128,187 @@
 	/>
 </div>
 
-<div class="px-4 flex flex-col gap-2">
-	<div class="flex justify-between items-center gap-2 flex-wrap">
-		<p class="text-lg">{selectedDateFormatted}</p>
+<div class="px-4 flex flex-col gap-4 pb-6">
+	<!-- Date Navigation -->
+	<div class="bg-secondary rounded-xl p-4 flex items-center justify-between gap-3">
+		<button
+			onclick={() => selectedDate > 1 && selectedDate--}
+			disabled={selectedDate <= 1}
+			class="w-10 h-10 rounded-full flex items-center justify-center hover:bg-primary transition-colors disabled:opacity-30 text-lg flex-shrink-0"
+			aria-label={$t('worshipTracker.prevDay')}
+		>
+			‹
+		</button>
+		<div class="text-center min-w-0">
+			<p class="font-bold text-base truncate">{selectedDateFormatted.split(',')[0]}</p>
+			<p class="text-sm opacity-70 truncate">
+				{selectedDateFormatted.split(',').slice(1).join(',').trim()}
+			</p>
+			{#if !isToday}
+				<button
+					onclick={() => (selectedDate = getCurrentDate())}
+					class="text-xs text-blue-500 hover:text-blue-600 mt-0.5 underline"
+				>
+					Hari Ini
+				</button>
+			{/if}
+		</div>
+		<button
+			onclick={() => selectedDate < dayInMonth && selectedDate++}
+			disabled={selectedDate >= dayInMonth}
+			class="w-10 h-10 rounded-full flex items-center justify-center hover:bg-primary transition-colors disabled:opacity-30 text-lg flex-shrink-0"
+			aria-label={$t('worshipTracker.nextDay')}
+		>
+			›
+		</button>
+	</div>
+
+	<!-- Progress + Streak -->
+	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
+		{#if currentStreak > 0}
+			<div
+				class="flex items-center gap-3 pb-3 border-b border-foreground/10"
+			>
+				<span class="text-3xl leading-none">🔥</span>
+				<div class="flex-1 min-w-0">
+					<p class="font-bold text-lg leading-none tabular-nums">
+						{currentStreak}
+						<span class="text-sm font-normal opacity-70">hari berturut-turut</span>
+					</p>
+					<p class="text-xs opacity-50 mt-0.5">Sholat wajib terpenuhi</p>
+				</div>
+				{#if currentStreak >= 7}
+					<span
+						class="text-xs px-2 py-1 rounded-full font-semibold bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 flex-shrink-0"
+					>
+						{#if currentStreak >= 30}🏆 30+ hari
+						{:else if currentStreak >= 14}⭐ 2 minggu
+						{:else}🌟 1 minggu{/if}
+					</span>
+				{/if}
+			</div>
+		{/if}
+		<div>
+			<div class="flex justify-between items-center text-sm mb-1.5">
+				<span class="font-medium">🕌 {$t('worshipTracker.fardPrayer')}</span>
+				<span
+					class="font-bold tabular-nums {fardCompleted === 5
+						? 'text-green-600 dark:text-green-400'
+						: ''}">{fardCompleted}/5</span
+				>
+			</div>
+			<div class="w-full bg-primary rounded-full h-2.5 overflow-hidden">
+				<div
+					class="h-2.5 rounded-full transition-all duration-300 {fardCompleted === 5
+						? 'bg-green-500'
+						: 'bg-blue-500'}"
+					style="width: {(fardCompleted / 5) * 100}%"
+				></div>
+			</div>
+		</div>
+		<div>
+			<div class="flex justify-between items-center text-sm mb-1.5">
+				<span class="font-medium">⭐ {$t('worshipTracker.sunnahPrayer')}</span>
+				<span
+					class="font-bold tabular-nums {sunnahCompleted === 7
+						? 'text-amber-600 dark:text-amber-400'
+						: ''}">{sunnahCompleted}/7</span
+				>
+			</div>
+			<div class="w-full bg-primary rounded-full h-2.5 overflow-hidden">
+				<div
+					class="h-2.5 rounded-full transition-all duration-300 bg-amber-500"
+					style="width: {(sunnahCompleted / 7) * 100}%"
+				></div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Celebration banner -->
+	{#if fardCompleted === 5}
+		<div
+			class="bg-green-100 dark:bg-green-950 border border-green-400 dark:border-green-700 rounded-xl p-4 text-center"
+		>
+			<p class="text-2xl mb-1">{sunnahCompleted === 7 ? '🏆' : '🎉'}</p>
+			<p class="font-bold text-green-700 dark:text-green-300">
+				{sunnahCompleted === 7 ? 'Sempurna! Wajib & Sunnah selesai.' : 'Sholat Wajib Selesai!'}
+			</p>
+			{#if sunnahCompleted < 7}
+				<p class="text-xs text-green-600 dark:text-green-400 mt-1">
+					Tambah {7 - sunnahCompleted} sholat sunnah untuk hari yang lebih sempurna.
+				</p>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Fard Prayers -->
+	<div>
+		<h2 class="text-sm font-bold uppercase tracking-wide opacity-60 mb-3">
+			🕌 {$t('worshipTracker.fardPrayer')}
+		</h2>
+		<div class="grid grid-cols-2 gap-3">
+			{#each FARD_PRAYERS as prayer (prayer.id)}
+				{@const done = $logPrayer[selectedYYYYMMDD]?.[prayer.id] === 1}
+				<button
+					onclick={() => togglePrayer(prayer.id)}
+					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id === '5'
+						? 'col-span-2'
+						: ''} {done
+						? 'bg-green-100 dark:bg-green-950 border-green-500'
+						: 'bg-secondary border-transparent hover:border-foreground/20 active:scale-95'}"
+					aria-pressed={done}
+					aria-label="{done ? 'Batalkan' : 'Tandai'} {prayer.title}"
+				>
+					<span class="text-3xl">{prayer.emoji}</span>
+					<span class="font-semibold text-sm">{prayer.title}</span>
+					{#if done}
+						<span class="text-xs text-green-600 dark:text-green-400 font-medium">✓ Selesai</span>
+					{:else}
+						<span class="text-xs opacity-30">Belum</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Sunnah Prayers -->
+	<div>
+		<h2 class="text-sm font-bold uppercase tracking-wide opacity-60 mb-3">
+			⭐ {$t('worshipTracker.sunnahPrayer')}
+		</h2>
+		<div class="grid grid-cols-2 gap-3">
+			{#each SUNNAH_PRAYERS as prayer (prayer.id)}
+				{@const done = $logPrayer[selectedYYYYMMDD]?.[prayer.id] === 1}
+				<button
+					onclick={() => togglePrayer(prayer.id)}
+					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id === '12'
+						? 'col-span-2'
+						: ''} {done
+						? 'bg-amber-100 dark:bg-amber-950 border-amber-500'
+						: 'bg-secondary border-transparent hover:border-foreground/20 active:scale-95'}"
+					aria-pressed={done}
+					aria-label="{done ? 'Batalkan' : 'Tandai'} {prayer.title}"
+				>
+					<span class="text-3xl">{prayer.emoji}</span>
+					<span class="font-semibold text-sm text-center leading-tight">{prayer.title}</span>
+					{#if done}
+						<span class="text-xs text-amber-600 dark:text-amber-400 font-medium">✓ Selesai</span>
+					{:else}
+						<span class="text-xs opacity-30">Belum</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<!-- View Recap -->
+	<div class="flex justify-end pt-2">
 		<a href="/pencatat-ibadah/rekap/">
-			<Button onClick={() => {}} class="text-sm justify-center items-center">
+			<Button onClick={() => {}} variant="outline" color="primary">
 				{$t('worshipTracker.viewRecap')}
 				<ArrowRightIcon size="sm" />
 			</Button>
 		</a>
-	</div>
-	<div
-		class="flex gap-2 w-full overflow-x-scroll pb-4 pt-2 px-4 mt-2 scroll-smooth snap-x snap-proximity"
-	>
-		{#each dayRanges as day (day)}
-			<button
-				class={`snap-center min-w-20 rounded-lg flex items-center justify-center py-2 px-4 border focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${day === selectedDate ? 'bg-primary font-bold border-blue-500 border-2' : 'bg-secondary'}`}
-				onclick={() => {
-					selectedDate = day;
-				}}
-				id={`day-${day}`}
-			>
-				{day}
-			</button>
-		{/each}
-	</div>
-	<div class="grid gap-2">
-		{#each PRAYER_LIST as prayer (prayer.key)}
-			<CardShadow class="flex items-center">
-				<input
-					id={`chk-${prayer.id}`}
-					type="checkbox"
-					value={prayer.id}
-					name={prayer.title}
-					onchange={handleCheckUncheck}
-					checked={$logPrayer && $logPrayer?.[selectedYYYYMMDD]
-						? $logPrayer[selectedYYYYMMDD]?.[`${prayer.id}` as LogPrayerItemKey] === 1
-						: false}
-					class="peer w-6 h-6 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-				/>
-				<label
-					for={`chk-${prayer.id}`}
-					class="w-full ms-2 text-sm font-medium text-foreground peer-checked:line-through"
-				>
-					{prayer.title}
-				</label>
-			</CardShadow>
-		{/each}
 	</div>
 </div>
 

--- a/src/routes/pencatat-ibadah/+page.svelte
+++ b/src/routes/pencatat-ibadah/+page.svelte
@@ -39,6 +39,12 @@
 	let selectedDate = $state(getCurrentDate());
 	let isToday = $derived(selectedDate === getCurrentDate());
 
+	let hasAnyData = $derived(
+		Object.values($logPrayer).some((d) => Object.values(d).some((v) => v === 1))
+	);
+	let welcomeDismissed = $state(false);
+	let showWelcome = $derived(!hasAnyData && !welcomeDismissed);
+
 	let selectedYYYYMMDD = $derived.by(() => {
 		const d = new Date();
 		d.setDate(selectedDate);
@@ -129,6 +135,49 @@
 </div>
 
 <div class="px-4 flex flex-col gap-4 pb-6">
+	<!-- Welcome wizard (first-time users) -->
+	{#if showWelcome}
+		<div class="bg-secondary rounded-xl p-5 border-2 border-blue-200 dark:border-blue-800">
+			<div class="flex items-start justify-between mb-3">
+				<div>
+					<h2 class="font-bold text-lg">👋 Selamat Datang!</h2>
+					<p class="text-sm opacity-60 mt-0.5">Pencatat Ibadah Harian</p>
+				</div>
+				<button
+					onclick={() => (welcomeDismissed = true)}
+					class="w-7 h-7 rounded-full flex items-center justify-center hover:bg-primary transition-colors opacity-40 hover:opacity-100 text-sm"
+					aria-label="Tutup"
+				>
+					✕
+				</button>
+			</div>
+			<p class="text-sm opacity-80 mb-4 leading-relaxed">
+				Catat sholat harianmu untuk refleksi diri. Semua data hanya tersimpan di perambanmu —
+				<strong>privasi aman & gratis sepenuhnya</strong>.
+			</p>
+			<div class="grid grid-cols-3 gap-2 mb-4">
+				<div class="bg-primary rounded-lg p-3 text-center">
+					<p class="text-2xl">🕌</p>
+					<p class="text-xs mt-1 font-semibold">5 Wajib</p>
+				</div>
+				<div class="bg-primary rounded-lg p-3 text-center">
+					<p class="text-2xl">⭐</p>
+					<p class="text-xs mt-1 font-semibold">7 Sunnah</p>
+				</div>
+				<div class="bg-primary rounded-lg p-3 text-center">
+					<p class="text-2xl">🔥</p>
+					<p class="text-xs mt-1 font-semibold">Streak</p>
+				</div>
+			</div>
+			<button
+				onclick={() => (welcomeDismissed = true)}
+				class="w-full py-2.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold transition-colors"
+			>
+				Mulai Catat →
+			</button>
+		</div>
+	{/if}
+
 	<!-- Date Navigation -->
 	<div class="bg-secondary rounded-xl p-4 flex items-center justify-between gap-3">
 		<button

--- a/src/routes/pencatat-ibadah/+page.svelte
+++ b/src/routes/pencatat-ibadah/+page.svelte
@@ -16,14 +16,18 @@
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import { t } from '$lib/translations/store';
 
-	const FARD_PRAYERS: Array<{ key: PrayerKey; title: string; id: LogPrayerItemKey; emoji: string }> =
-		[
-			{ key: 'Fajr', title: 'Subuh', id: '1', emoji: '🌅' },
-			{ key: 'Dhuhr', title: 'Dzuhur', id: '2', emoji: '☀️' },
-			{ key: 'Asr', title: 'Ashar', id: '3', emoji: '🌤️' },
-			{ key: 'Maghrib', title: 'Maghrib', id: '4', emoji: '🌆' },
-			{ key: 'Isha', title: 'Isya', id: '5', emoji: '🌙' }
-		];
+	const FARD_PRAYERS: Array<{
+		key: PrayerKey;
+		title: string;
+		id: LogPrayerItemKey;
+		emoji: string;
+	}> = [
+		{ key: 'Fajr', title: 'Subuh', id: '1', emoji: '🌅' },
+		{ key: 'Dhuhr', title: 'Dzuhur', id: '2', emoji: '☀️' },
+		{ key: 'Asr', title: 'Ashar', id: '3', emoji: '🌤️' },
+		{ key: 'Maghrib', title: 'Maghrib', id: '4', emoji: '🌆' },
+		{ key: 'Isha', title: 'Isya', id: '5', emoji: '🌙' }
+	];
 
 	const SUNNAH_PRAYERS: Array<{ title: string; id: LogPrayerItemKey; emoji: string }> = [
 		{ title: 'Qabliyah Subuh', id: '6', emoji: '🌅' },
@@ -215,9 +219,7 @@
 	<!-- Progress + Streak -->
 	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
 		{#if currentStreak > 0}
-			<div
-				class="flex items-center gap-3 pb-3 border-b border-foreground/10"
-			>
+			<div class="flex items-center gap-3 pb-3 border-b border-foreground/10">
 				<span class="text-3xl leading-none">🔥</span>
 				<div class="flex-1 min-w-0">
 					<p class="font-bold text-lg leading-none tabular-nums">
@@ -300,7 +302,8 @@
 				{@const done = $logPrayer[selectedYYYYMMDD]?.[prayer.id] === 1}
 				<button
 					onclick={() => togglePrayer(prayer.id)}
-					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id === '5'
+					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id ===
+					'5'
 						? 'col-span-2'
 						: ''} {done
 						? 'bg-green-100 dark:bg-green-950 border-green-500'
@@ -330,7 +333,8 @@
 				{@const done = $logPrayer[selectedYYYYMMDD]?.[prayer.id] === 1}
 				<button
 					onclick={() => togglePrayer(prayer.id)}
-					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id === '12'
+					class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer {prayer.id ===
+					'12'
 						? 'col-span-2'
 						: ''} {done
 						? 'bg-amber-100 dark:bg-amber-950 border-amber-500'

--- a/src/routes/pencatat-ibadah/rekap/+page.svelte
+++ b/src/routes/pencatat-ibadah/rekap/+page.svelte
@@ -370,7 +370,11 @@
 						onclick={() => {
 							selectedDay = isSelected ? null : cell.key;
 						}}
-						class="aspect-square rounded-lg text-xs transition-all {getCellClass(cell.key, isToday, isSelected)}"
+						class="aspect-square rounded-lg text-xs transition-all {getCellClass(
+							cell.key,
+							isToday,
+							isSelected
+						)}"
 						aria-label="Tanggal {cell.day}"
 						aria-pressed={isSelected}
 					>
@@ -534,9 +538,7 @@
 						? 'bg-secondary border-foreground/10'
 						: 'bg-primary/30 border-transparent opacity-50'}"
 				>
-					<span class="text-2xl leading-none {ach.unlocked ? '' : 'grayscale'}"
-						>{ach.emoji}</span
-					>
+					<span class="text-2xl leading-none {ach.unlocked ? '' : 'grayscale'}">{ach.emoji}</span>
 					<div class="min-w-0 flex-1">
 						<p class="text-sm font-semibold leading-tight">{ach.title}</p>
 						<p class="text-xs opacity-50 leading-tight mt-0.5">{ach.desc}</p>

--- a/src/routes/pencatat-ibadah/rekap/+page.svelte
+++ b/src/routes/pencatat-ibadah/rekap/+page.svelte
@@ -156,6 +156,120 @@
 		return getDayjsFormatted(selectedDay, 'YYYYMMDD').format('dddd, DD MMMM YYYY');
 	});
 
+	let monthlyPct = $derived.by(() => {
+		const prefix = `${selectedYear}${String(selectedMonthIndex + 1).padStart(2, '0')}`;
+		const keys = Object.keys($logPrayer).filter((k) => k.startsWith(prefix));
+		if (keys.length === 0) return 0;
+		const total = keys.reduce((sum, key) => {
+			return sum + FARD_IDS.filter((id) => $logPrayer[key]?.[id as LogPrayerItemKey] === 1).length;
+		}, 0);
+		return Math.round((total / (keys.length * 5)) * 100);
+	});
+
+	let globalStats = $derived.by(() => {
+		const allKeys = Object.keys($logPrayer);
+		const totalPrayers = allKeys.reduce((sum, key) => {
+			return sum + Object.values($logPrayer[key]).filter((v) => v === 1).length;
+		}, 0);
+		const totalPerfectDays = allKeys.filter((k) =>
+			FARD_IDS.every((id) => $logPrayer[k]?.[id as LogPrayerItemKey] === 1)
+		).length;
+		const hasSunnah = allKeys.some((k) =>
+			SUNNAH_IDS.some((id) => $logPrayer[k]?.[id as LogPrayerItemKey] === 1)
+		);
+		const hasFullSunnahDay = allKeys.some((k) =>
+			SUNNAH_IDS.every((id) => $logPrayer[k]?.[id as LogPrayerItemKey] === 1)
+		);
+
+		// Best streak ever (walk sorted keys, check consecutive calendar days)
+		const sorted = [...allKeys].sort();
+		let best = 0;
+		let cur = 0;
+		for (let i = 0; i < sorted.length; i++) {
+			const key = sorted[i];
+			const perfect = FARD_IDS.every((id) => $logPrayer[key]?.[id as LogPrayerItemKey] === 1);
+			if (!perfect) {
+				cur = 0;
+				continue;
+			}
+			if (i > 0) {
+				const prev = sorted[i - 1];
+				const prevD = new Date(+prev.slice(0, 4), +prev.slice(4, 6) - 1, +prev.slice(6, 8));
+				const currD = new Date(+key.slice(0, 4), +key.slice(4, 6) - 1, +key.slice(6, 8));
+				const diff = Math.round((currD.getTime() - prevD.getTime()) / 86400000);
+				cur = diff === 1 ? cur + 1 : 1;
+			} else {
+				cur = 1;
+			}
+			best = Math.max(best, cur);
+		}
+
+		return { totalPrayers, totalPerfectDays, hasSunnah, hasFullSunnahDay, bestStreak: best };
+	});
+
+	let achievements = $derived.by(() => {
+		const { totalPrayers, totalPerfectDays, hasSunnah, hasFullSunnahDay, bestStreak } = globalStats;
+		const bs = Math.max(currentStreak, bestStreak);
+		return [
+			{
+				id: 'first_prayer',
+				emoji: '🌱',
+				title: 'Langkah Pertama',
+				desc: 'Catat sholat pertamamu',
+				unlocked: totalPrayers > 0
+			},
+			{
+				id: 'first_sunnah',
+				emoji: '💫',
+				title: 'Sunnah Perdana',
+				desc: 'Catat sholat sunnah pertamamu',
+				unlocked: hasSunnah
+			},
+			{
+				id: 'first_perfect',
+				emoji: '⭐',
+				title: 'Hari Sempurna',
+				desc: '5 sholat wajib dalam sehari',
+				unlocked: totalPerfectDays > 0
+			},
+			{
+				id: 'sunnah_complete',
+				emoji: '✨',
+				title: 'Sunnah Lengkap',
+				desc: 'Semua 7 sunnah dalam sehari',
+				unlocked: hasFullSunnahDay
+			},
+			{
+				id: 'perfect_10',
+				emoji: '🏅',
+				title: '10 Hari Sempurna',
+				desc: '10 hari dengan sholat wajib lengkap',
+				unlocked: totalPerfectDays >= 10
+			},
+			{
+				id: 'streak_7',
+				emoji: '🔥',
+				title: 'Seminggu Beruntun',
+				desc: '7 hari berturut-turut sholat wajib',
+				unlocked: bs >= 7
+			},
+			{
+				id: 'streak_14',
+				emoji: '💪',
+				title: 'Dua Minggu Beruntun',
+				desc: '14 hari berturut-turut sholat wajib',
+				unlocked: bs >= 14
+			},
+			{
+				id: 'streak_30',
+				emoji: '🏆',
+				title: 'Sebulan Beruntun',
+				desc: '30 hari berturut-turut sholat wajib',
+				unlocked: bs >= 30
+			}
+		];
+	});
+
 	let selectedDayFardCount = $derived.by(() => {
 		if (!selectedDay) return 0;
 		return getFardCount(selectedDay);
@@ -375,6 +489,67 @@
 	{:else}
 		<p class="text-sm text-center opacity-40 py-2">{$t('worshipTracker.tapForDetail')}</p>
 	{/if}
+
+	<!-- Monthly completion rate -->
+	{#if monthStats.daysTracked > 0}
+		<div class="bg-secondary rounded-xl p-4">
+			<div class="flex justify-between items-center text-sm mb-2">
+				<span class="font-medium">📊 Kelengkapan Sholat Wajib</span>
+				<span
+					class="font-bold tabular-nums {monthlyPct === 100
+						? 'text-green-600 dark:text-green-400'
+						: ''}">{monthlyPct}%</span
+				>
+			</div>
+			<div class="w-full bg-primary rounded-full h-3 overflow-hidden">
+				<div
+					class="h-3 rounded-full transition-all duration-500 {monthlyPct === 100
+						? 'bg-green-500'
+						: monthlyPct >= 80
+							? 'bg-blue-500'
+							: monthlyPct >= 50
+								? 'bg-yellow-500'
+								: 'bg-orange-500'}"
+					style="width: {monthlyPct}%"
+				></div>
+			</div>
+			<p class="text-xs opacity-50 mt-2">
+				dari {monthStats.daysTracked} hari yang dicatat di bulan {monthNames[selectedMonthIndex]}
+			</p>
+		</div>
+	{/if}
+
+	<!-- Achievements -->
+	<div>
+		<h2 class="font-bold mb-3 flex items-center gap-2">
+			🏅 Pencapaian
+			<span class="text-xs font-normal opacity-50">
+				({achievements.filter((a) => a.unlocked).length}/{achievements.length})
+			</span>
+		</h2>
+		<div class="grid grid-cols-2 gap-2">
+			{#each achievements as ach (ach.id)}
+				<div
+					class="flex items-center gap-3 p-3 rounded-xl border-2 transition-all {ach.unlocked
+						? 'bg-secondary border-foreground/10'
+						: 'bg-primary/30 border-transparent opacity-50'}"
+				>
+					<span class="text-2xl leading-none {ach.unlocked ? '' : 'grayscale'}"
+						>{ach.emoji}</span
+					>
+					<div class="min-w-0 flex-1">
+						<p class="text-sm font-semibold leading-tight">{ach.title}</p>
+						<p class="text-xs opacity-50 leading-tight mt-0.5">{ach.desc}</p>
+					</div>
+					{#if ach.unlocked}
+						<span class="text-green-500 text-sm flex-shrink-0">✓</span>
+					{:else}
+						<span class="opacity-30 text-sm flex-shrink-0">🔒</span>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
 </div>
 
 <SeoText variant="CATAT_IBADAH" />

--- a/src/routes/pencatat-ibadah/rekap/+page.svelte
+++ b/src/routes/pencatat-ibadah/rekap/+page.svelte
@@ -8,24 +8,164 @@
 		META_TITLE_PENCATAT_IBADAH,
 		TITLE_CONSTANTS
 	} from '$lib/constants';
-	import { formatDate, getAllMonths } from '$lib/utils/date';
-	import { logPrayer } from '$store';
+	import { getDayInMonth, getDayjsFormatted } from '$lib/utils/date';
+	import { logPrayer, type LogPrayerItemKey } from '$store';
 
-	let monthRanges = getAllMonths();
+	const FARD_IDS = ['1', '2', '3', '4', '5'] as const;
+	const SUNNAH_IDS = ['6', '7', '8', '9', '10', '11', '12'] as const;
 
-	let selectedMonth = $state(formatDate(new Date().toISOString(), 'MMMM'));
+	const PRAYER_LABELS: Record<string, string> = {
+		'1': 'Subuh',
+		'2': 'Dzuhur',
+		'3': 'Ashar',
+		'4': 'Maghrib',
+		'5': 'Isya',
+		'6': 'Qabliyah Subuh',
+		'7': 'Qabliyah Dzuhur',
+		'8': "Ba'diyah Dzuhur",
+		'9': "Ba'diyah Maghrib",
+		'10': "Ba'diyah Isya",
+		'11': 'Dhuha',
+		'12': 'Tahajjud'
+	};
 
-	let selectedLogPrayer = $derived.by(() => {
-		const selectedIndex = monthRanges.findIndex((month) => month === selectedMonth) + 1;
-		const selectedIndexTrailZero = selectedIndex < 10 ? `0${selectedIndex}` : `${selectedIndex}`;
+	const PRAYER_EMOJIS: Record<string, string> = {
+		'1': '🌅',
+		'2': '☀️',
+		'3': '🌤️',
+		'4': '🌆',
+		'5': '🌙',
+		'6': '🌅',
+		'7': '☀️',
+		'8': '✨',
+		'9': '🌆',
+		'10': '🌙',
+		'11': '🌄',
+		'12': '🌌'
+	};
 
-		const allKeys = Object.keys($logPrayer) || [];
-		const selectedKeys = allKeys.filter((key) => {
-			const m = key.substring(4, 6);
-			return m === selectedIndexTrailZero;
-		});
+	const DAY_NAMES = ['Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab', 'Min'];
 
-		return selectedKeys;
+	const today = new Date();
+	const todayKey = `${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`;
+
+	let selectedYear = $state(today.getFullYear());
+	let selectedMonthIndex = $state(today.getMonth()); // 0–11
+	let selectedDay = $state<string | null>(null); // YYYYMMDD
+
+	const monthNames = [
+		'Januari',
+		'Februari',
+		'Maret',
+		'April',
+		'Mei',
+		'Juni',
+		'Juli',
+		'Agustus',
+		'September',
+		'Oktober',
+		'November',
+		'Desember'
+	];
+
+	function prevMonth() {
+		if (selectedMonthIndex === 0) {
+			selectedMonthIndex = 11;
+			selectedYear -= 1;
+		} else {
+			selectedMonthIndex -= 1;
+		}
+		selectedDay = null;
+	}
+
+	function nextMonth() {
+		if (selectedMonthIndex === 11) {
+			selectedMonthIndex = 0;
+			selectedYear += 1;
+		} else {
+			selectedMonthIndex += 1;
+		}
+		selectedDay = null;
+	}
+
+	let calendarDays = $derived.by(() => {
+		const firstDate = new Date(selectedYear, selectedMonthIndex, 1);
+		const firstDayOfWeek = firstDate.getDay(); // 0=Sun
+		const adjustedFirst = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1; // Mon=0
+		const daysInMonth = getDayInMonth(firstDate.toISOString());
+
+		const cells: Array<{ day: number; key: string } | null> = [];
+		for (let i = 0; i < adjustedFirst; i++) cells.push(null);
+		for (let d = 1; d <= daysInMonth; d++) {
+			const mm = String(selectedMonthIndex + 1).padStart(2, '0');
+			const dd = String(d).padStart(2, '0');
+			cells.push({ day: d, key: `${selectedYear}${mm}${dd}` });
+		}
+		return cells;
+	});
+
+	let monthStats = $derived.by(() => {
+		const prefix = `${selectedYear}${String(selectedMonthIndex + 1).padStart(2, '0')}`;
+		const keys = Object.keys($logPrayer).filter((k) => k.startsWith(prefix));
+		const perfectDays = keys.filter((k) =>
+			FARD_IDS.every((id) => $logPrayer[k]?.[id as LogPrayerItemKey] === 1)
+		).length;
+		return { daysTracked: keys.length, perfectDays };
+	});
+
+	let currentStreak = $derived.by(() => {
+		const base = new Date();
+		const baseKey = `${base.getFullYear()}${String(base.getMonth() + 1).padStart(2, '0')}${String(base.getDate()).padStart(2, '0')}`;
+		const todayDone =
+			$logPrayer[baseKey] &&
+			FARD_IDS.every((id) => $logPrayer[baseKey]?.[id as LogPrayerItemKey] === 1);
+		let count = 0;
+		for (let i = todayDone ? 0 : 1; i < 366; i++) {
+			const d = new Date(base);
+			d.setDate(base.getDate() - i);
+			const key = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+			const dayData = $logPrayer[key];
+			if (!dayData || !FARD_IDS.every((id) => dayData[id as LogPrayerItemKey] === 1)) break;
+			count++;
+		}
+		return count;
+	});
+
+	function getFardCount(key: string): number {
+		const dayData = $logPrayer[key];
+		if (!dayData) return -1;
+		return FARD_IDS.filter((id) => dayData[id as LogPrayerItemKey] === 1).length;
+	}
+
+	function getCellClass(key: string, isToday: boolean, isSelected: boolean): string {
+		const todayRing = isToday ? ' ring-2 ring-blue-500' : '';
+		if (isSelected) return 'bg-blue-500 text-white font-bold';
+		const fardCount = getFardCount(key);
+		if (fardCount === -1) return `text-foreground/50${todayRing}`;
+		if (fardCount === 0)
+			return `bg-red-200/60 dark:bg-red-900/40 text-red-700 dark:text-red-300${todayRing}`;
+		if (fardCount <= 2)
+			return `bg-orange-200/60 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300${todayRing}`;
+		if (fardCount <= 4)
+			return `bg-yellow-200/60 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300${todayRing}`;
+		return `bg-green-200/60 dark:bg-green-900/40 text-green-800 dark:text-green-200 font-semibold${todayRing}`;
+	}
+
+	let selectedDayFormatted = $derived.by(() => {
+		if (!selectedDay) return '';
+		return getDayjsFormatted(selectedDay, 'YYYYMMDD').format('dddd, DD MMMM YYYY');
+	});
+
+	let selectedDayFardCount = $derived.by(() => {
+		if (!selectedDay) return 0;
+		return getFardCount(selectedDay);
+	});
+
+	let selectedDaySunnahCount = $derived.by(() => {
+		if (!selectedDay) return 0;
+		const dayData = $logPrayer[selectedDay];
+		if (!dayData) return 0;
+		return SUNNAH_IDS.filter((id) => dayData[id as LogPrayerItemKey] === 1).length;
 	});
 </script>
 
@@ -38,9 +178,7 @@
 </svelte:head>
 
 <div class="flex gap-2 px-4 mb-4">
-	<h1 class="text-3xl font-bold">
-		⏺️ {$t('worshipTracker.logRecap')}
-	</h1>
+	<h1 class="text-3xl font-bold">⏺️ {$t('worshipTracker.logRecap')}</h1>
 </div>
 
 <div class="px-4 mb-4">
@@ -55,63 +193,188 @@
 	/>
 </div>
 
-<div class="px-4 flex flex-col gap-2">
-	<div
-		class="flex gap-2 w-full overflow-x-scroll pb-4 pt-2 px-4 mt-2 scroll-smooth snap-x snap-proximity"
-	>
-		{#each monthRanges as month (month)}
-			<button
-				class={`snap-center rounded-lg flex items-center justify-center py-2 px-4 border focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${month === selectedMonth ? 'bg-primary font-bold border-blue-500 border-2' : 'bg-secondary'}`}
-				onclick={() => {
-					selectedMonth = month;
-				}}
-				id={`month-${month?.toLowerCase()}`}
-			>
-				{month}
-			</button>
-		{/each}
+<div class="px-4 flex flex-col gap-4 pb-8">
+	<!-- Month Navigation -->
+	<div class="bg-secondary rounded-xl p-4 flex items-center justify-between">
+		<button
+			onclick={prevMonth}
+			class="w-10 h-10 rounded-full flex items-center justify-center hover:bg-primary transition-colors text-lg"
+			aria-label={$t('hijriCalendar.prevMonth')}
+		>
+			‹
+		</button>
+		<div class="text-center">
+			<p class="font-bold text-lg">{monthNames[selectedMonthIndex]}</p>
+			<p class="text-sm opacity-70">{selectedYear}</p>
+		</div>
+		<button
+			onclick={nextMonth}
+			class="w-10 h-10 rounded-full flex items-center justify-center hover:bg-primary transition-colors text-lg"
+			aria-label={$t('hijriCalendar.nextMonth')}
+		>
+			›
+		</button>
 	</div>
-	<div
-		class="mt-4 mb-8 min-h-[300px] p-4 relative overflow-x-auto shadow-md rounded-lg border-2 border-secondary"
-	>
-		{#if selectedLogPrayer.length > 0}
-			<table class="table-stripped">
-				<thead>
-					<tr>
-						<th scope="col">
-							{$t('worshipTracker.date')}
-						</th>
-						<th scope="col">Subuh</th>
-						<th scope="col">Dzuhur</th>
-						<th scope="col">Ashar</th>
-						<th scope="col">Maghrib</th>
-						<th scope="col">Isya</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each selectedLogPrayer as logKey (logKey)}
-						<tr>
-							<td>{logKey}</td>
-							{#each Object.entries($logPrayer[logKey]) as [k, v]}
-								<td data-col={k} class="text-center">{v === 1 ? '✅' : '❌'}</td>
-							{/each}
-						</tr>
-					{/each}
-				</tbody>
-			</table>
-		{:else}
-			<div class="m-6 flex flex-col gap-2 justify-center items-center p-4">
-				<p class="text-2xl text-center font-bold">
-					{$t('worshipTracker.noRecapData', { month: selectedMonth })}
-				</p>
-				<img
-					src="/images/illustrasion-error.svg"
-					alt="The monsters eating your page"
-					class="w-[80%] mt-8 mb-8"
-				/>
+
+	<!-- Stats -->
+	<div class="grid grid-cols-3 gap-2">
+		<div class="bg-secondary rounded-xl p-3 text-center">
+			<p class="text-2xl font-bold tabular-nums">{monthStats.daysTracked}</p>
+			<p class="text-xs opacity-60 mt-1 leading-tight">{$t('worshipTracker.daysTracked')}</p>
+		</div>
+		<div class="bg-secondary rounded-xl p-3 text-center">
+			<p class="text-2xl font-bold tabular-nums text-green-600 dark:text-green-400">
+				{monthStats.perfectDays}
+			</p>
+			<p class="text-xs opacity-60 mt-1 leading-tight">{$t('worshipTracker.perfectDays')}</p>
+		</div>
+		<div class="bg-secondary rounded-xl p-3 text-center">
+			<p class="text-2xl font-bold tabular-nums text-orange-600 dark:text-orange-400">
+				{#if currentStreak > 0}🔥{/if}{currentStreak}
+			</p>
+			<p class="text-xs opacity-60 mt-1 leading-tight">{$t('worshipTracker.streak')}</p>
+		</div>
+	</div>
+
+	<!-- Calendar -->
+	<div class="bg-secondary rounded-xl p-3">
+		<!-- Day headers -->
+		<div class="grid grid-cols-7 gap-1 mb-1">
+			{#each DAY_NAMES as name}
+				<div class="text-center text-xs font-medium opacity-40 py-1">{name}</div>
+			{/each}
+		</div>
+		<!-- Day cells -->
+		<div class="grid grid-cols-7 gap-1">
+			{#each calendarDays as cell, i (i)}
+				{#if cell === null}
+					<div></div>
+				{:else}
+					{@const isToday = cell.key === todayKey}
+					{@const isSelected = cell.key === selectedDay}
+					<button
+						onclick={() => {
+							selectedDay = isSelected ? null : cell.key;
+						}}
+						class="aspect-square rounded-lg text-xs transition-all {getCellClass(cell.key, isToday, isSelected)}"
+						aria-label="Tanggal {cell.day}"
+						aria-pressed={isSelected}
+					>
+						{cell.day}
+					</button>
+				{/if}
+			{/each}
+		</div>
+
+		<!-- Legend -->
+		<div class="flex items-center gap-3 flex-wrap mt-3 pt-3 border-t border-foreground/10 text-xs">
+			<span class="opacity-50">{$t('worshipTracker.calendarLegend')}:</span>
+			<span class="flex items-center gap-1">
+				<span
+					class="w-3.5 h-3.5 rounded bg-red-200/60 dark:bg-red-900/40 inline-block border border-foreground/10"
+				></span>
+				0/5
+			</span>
+			<span class="flex items-center gap-1">
+				<span
+					class="w-3.5 h-3.5 rounded bg-orange-200/60 dark:bg-orange-900/40 inline-block border border-foreground/10"
+				></span>
+				1–2/5
+			</span>
+			<span class="flex items-center gap-1">
+				<span
+					class="w-3.5 h-3.5 rounded bg-yellow-200/60 dark:bg-yellow-900/40 inline-block border border-foreground/10"
+				></span>
+				3–4/5
+			</span>
+			<span class="flex items-center gap-1">
+				<span
+					class="w-3.5 h-3.5 rounded bg-green-200/60 dark:bg-green-900/40 inline-block border border-foreground/10"
+				></span>
+				5/5
+			</span>
+		</div>
+	</div>
+
+	<!-- Day Detail Panel -->
+	{#if selectedDay}
+		<div class="bg-secondary rounded-xl p-4 border-2 border-blue-200 dark:border-blue-900">
+			<div class="flex items-start justify-between mb-4">
+				<div>
+					<h3 class="font-bold">{selectedDayFormatted}</h3>
+					<p class="text-xs opacity-60 mt-0.5">
+						{selectedDayFardCount}/5 wajib · {selectedDaySunnahCount}/7 sunnah
+					</p>
+				</div>
+				<button
+					onclick={() => (selectedDay = null)}
+					class="w-7 h-7 rounded-full flex items-center justify-center hover:bg-primary transition-colors opacity-50 hover:opacity-100 text-sm"
+					aria-label="Tutup detail"
+				>
+					✕
+				</button>
 			</div>
-		{/if}
-	</div>
+
+			{#if $logPrayer[selectedDay]}
+				<!-- Fard section -->
+				<div class="mb-4">
+					<p class="text-xs font-semibold uppercase tracking-wide opacity-50 mb-2">
+						🕌 Sholat Wajib
+					</p>
+					<div class="grid grid-cols-2 gap-y-2 gap-x-3">
+						{#each FARD_IDS as id}
+							{@const done = $logPrayer[selectedDay]?.[id as LogPrayerItemKey] === 1}
+							<div class="flex items-center gap-2 text-sm">
+								<span class={done ? 'text-green-500' : 'text-foreground/20'}>
+									{done ? '✅' : '⬜'}
+								</span>
+								<span class={done ? '' : 'opacity-40'}>
+									{PRAYER_EMOJIS[id]}
+									{PRAYER_LABELS[id]}
+								</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+
+				<!-- Sunnah section -->
+				<div>
+					<p class="text-xs font-semibold uppercase tracking-wide opacity-50 mb-2">
+						⭐ Sholat Sunnah
+					</p>
+					<div class="grid grid-cols-2 gap-y-2 gap-x-3">
+						{#each SUNNAH_IDS as id}
+							{@const done = $logPrayer[selectedDay]?.[id as LogPrayerItemKey] === 1}
+							<div class="flex items-center gap-2 text-sm">
+								<span class={done ? 'text-amber-500' : 'text-foreground/20'}>
+									{done ? '✅' : '⬜'}
+								</span>
+								<span class={done ? '' : 'opacity-40'}>
+									{PRAYER_EMOJIS[id]}
+									{PRAYER_LABELS[id]}
+								</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{:else}
+				<p class="text-sm opacity-50 text-center py-4">{$t('worshipTracker.noDataForDay')}</p>
+			{/if}
+		</div>
+	{:else if monthStats.daysTracked === 0}
+		<div class="flex flex-col gap-2 justify-center items-center p-6">
+			<p class="text-xl text-center font-bold">
+				{$t('worshipTracker.noRecapData', { month: monthNames[selectedMonthIndex] })}
+			</p>
+			<img
+				src="/images/illustrasion-error.svg"
+				alt="The monsters eating your page"
+				class="w-[60%] mt-4"
+			/>
+		</div>
+	{:else}
+		<p class="text-sm text-center opacity-40 py-2">{$t('worshipTracker.tapForDetail')}</p>
+	{/if}
 </div>
 
 <SeoText variant="CATAT_IBADAH" />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,14 +54,29 @@ export type BookmarkVerseItem = {
 
 export const lastReadVerses = writable<BookmarkVerseItem[]>([]);
 
-export type LogPrayerItemKey = '1' | '2' | '3' | '4' | '5';
+export type LogPrayerItemKey =
+	| '1'
+	| '2'
+	| '3'
+	| '4'
+	| '5'
+	| '6'
+	| '7'
+	| '8'
+	| '9'
+	| '10'
+	| '11'
+	| '12';
 export type LogPrayerItemValue = 1 | 0;
-export type LogPrayerValue = Record<LogPrayerItemKey, LogPrayerItemValue>;
 /**
- * Key is date in YYYYMMDD format
- * Value is record { id: 1 | 0 }
- * ID is ==> 1: Fajr, 2: Dhuhr, 3: Asr, 4: Maghrib, 5: Isha
+ * Key is a LogPrayerItemKey, value is 1 (done) or 0 (not done).
+ * Partial so old data without sunnah keys is still valid.
+ * 1=Subuh, 2=Dzuhur, 3=Ashar, 4=Maghrib, 5=Isya (fard)
+ * 6=Qabliyah Subuh, 7=Qabliyah Dzuhur, 8=Ba'diyah Dzuhur,
+ * 9=Ba'diyah Maghrib, 10=Ba'diyah Isya, 11=Dhuha, 12=Tahajjud (sunnah)
  */
+export type LogPrayerValue = Partial<Record<LogPrayerItemKey, LogPrayerItemValue>>;
+/** Key is date in YYYYMMDD format */
 export type LogPrayer = Record<string, LogPrayerValue>;
 
 export const logPrayer = writable<LogPrayer>({});


### PR DESCRIPTION
- Expand tracked prayers from 5 fard to 12 (fard + 7 sunnah: qabliyah/ba'diyah,
  dhuha, tahajjud). Data model uses Partial<Record<...>> for backwards compatibility.
- Replace scroll-list day picker with ← prev/next → date navigation + "Hari Ini" shortcut
- Add dual progress bars (wajib & sunnah) with streak counter (🔥 N hari berturut-turut)
- Add achievement badges for 7/14/30-day streaks
- Add celebration banner when all fard prayers are completed
- Prayer cards in 2-column grid; last item (Isya / Tahajjud) spans full width
- Recap page: replace table with interactive calendar grid — color-coded by fard count
  (red→orange→yellow→green) with today ring indicator
- Recap stats: 3-column layout with Days Tracked, Perfect Days, and global Streak
- Day detail panel: click any calendar cell to see fard + sunnah breakdown
- New i18n keys: fardPrayer, sunnahPrayer, daysTracked, perfectDays, streak,
  tapForDetail, noDataForDay, calendarLegend, prevDay, nextDay

https://claude.ai/code/session_01EJoMApXAV3dVCasBDvN8r7