### PR TITLE
fix(design-system): theme-based primary/secondary, info color, a11y improvements

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -25,18 +25,18 @@ html.forest {
 
 /* Pinky theme */
 html.pinky {
-	--color-primary: #da498d;
-	--color-secondary: #f564a9;
-	--color-foreground: #1f2937;
-	--color-foreground-secondary: #f2f9ff;
+	--color-primary: #be185d;
+	--color-secondary: #db2777;
+	--color-foreground: #fdf2f8;
+	--color-foreground-secondary: #fbcfe8;
 }
 
 /* Violet theme */
 html.violet {
-	--color-primary: #a78bfa;
-	--color-secondary: #8b5cf6;
+	--color-primary: #7c3aed;
+	--color-secondary: #6d28d9;
 	--color-foreground: #faf5ff;
-	--color-foreground-secondary: #f3e8ff;
+	--color-foreground-secondary: #ede9fe;
 }
 
 /* Halloween theme */
@@ -59,8 +59,8 @@ html.fall {
 html.pastel {
 	--color-primary: #ffa4a4;
 	--color-secondary: #ffbdbd;
-	--color-foreground: #2d3748;
-	--color-foreground-secondary: #4a5568;
+	--color-foreground: #1a202c;
+	--color-foreground-secondary: #2d3748;
 }
 
 /* Neon theme */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -191,18 +191,18 @@ export const THEMES = [
 	},
 	{
 		name: 'pinky',
-		bg: '#F564A9',
-		border: '#FFF'
+		bg: '#be185d',
+		border: '#fdf2f8'
 	},
 	{
 		name: 'violet',
-		bg: '#a78bfa',
-		border: '#FFF'
+		bg: '#7c3aed',
+		border: '#faf5ff'
 	},
 	{
 		name: 'pastel',
 		bg: '#ffa4a4',
-		border: '#ffbdbd'
+		border: '#1a202c'
 	},
 	{
 		name: 'neon',

--- a/src/lib/ui/Badge.svelte
+++ b/src/lib/ui/Badge.svelte
@@ -27,7 +27,7 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-primary text-foreground',
+			primary: 'bg-primary text-foreground border border-foreground/20',
 			secondary: 'bg-foreground text-primary',
 			info: 'bg-blue-600 text-white',
 			success: 'bg-green-600 text-white',

--- a/src/lib/ui/Badge.svelte
+++ b/src/lib/ui/Badge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	type Variant = 'solid' | 'subtle' | 'outline';
-	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Color = 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'danger';
 	type Size = 'sm' | 'md' | 'lg';
 
 	interface Props {
@@ -27,22 +27,25 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-blue-600 text-white',
+			primary: 'bg-primary text-foreground',
 			secondary: 'bg-foreground text-primary',
+			info: 'bg-blue-600 text-white',
 			success: 'bg-green-600 text-white',
 			warning: 'bg-orange-500 text-white',
 			danger: 'bg-red-600 text-white'
 		},
 		subtle: {
-			primary: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200',
+			primary: 'bg-primary text-foreground',
 			secondary: 'bg-secondary text-foreground',
+			info: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200',
 			success: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200',
 			warning: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200',
 			danger: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200'
 		},
 		outline: {
-			primary: 'border border-blue-500 text-blue-600 dark:text-blue-300',
+			primary: 'border border-foreground/40 text-foreground',
 			secondary: 'border border-foreground/30 text-foreground',
+			info: 'border border-blue-500 text-blue-600 dark:text-blue-300',
 			success: 'border border-green-500 text-green-600 dark:text-green-300',
 			warning: 'border border-orange-500 text-orange-600 dark:text-orange-300',
 			danger: 'border border-red-500 text-red-600 dark:text-red-300'

--- a/src/lib/ui/Banner.svelte
+++ b/src/lib/ui/Banner.svelte
@@ -65,7 +65,7 @@
 			type="button"
 			onclick={() => onDismiss?.()}
 			aria-label={ariaLabelClose}
-			class="flex-shrink-0 -m-1 p-1 rounded hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+			class="flex-shrink-0 -m-1 p-1 rounded hover:bg-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-2 focus-visible:ring-offset-primary cursor-pointer"
 		>
 			<XMarkIcon size="sm" />
 		</button>

--- a/src/lib/ui/Button.svelte
+++ b/src/lib/ui/Button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	type Variant = 'solid' | 'subtle' | 'outline';
-	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Color = 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'danger';
 	type Size = 'sm' | 'md' | 'lg';
 
 	interface Props {
@@ -35,15 +35,17 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-blue-600 text-white hover:bg-blue-700',
-			secondary: 'bg-primary text-foreground hover:bg-secondary',
+			primary: 'bg-primary text-foreground hover:bg-secondary',
+			secondary: 'bg-secondary text-foreground hover:opacity-90',
+			info: 'bg-blue-600 text-white hover:bg-blue-700',
 			success: 'bg-green-600 text-white hover:bg-green-700',
 			warning: 'bg-orange-500 text-white hover:bg-orange-600',
 			danger: 'bg-red-600 text-white hover:bg-red-700'
 		},
 		subtle: {
-			primary: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100',
+			primary: 'bg-primary text-foreground hover:opacity-80',
 			secondary: 'bg-secondary text-foreground hover:opacity-80',
+			info: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100',
 			success:
 				'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900 dark:text-green-100',
 			warning:
@@ -51,9 +53,9 @@
 			danger: 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-100'
 		},
 		outline: {
-			primary:
-				'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-900/40',
+			primary: 'border border-foreground/40 text-foreground hover:bg-primary',
 			secondary: 'border border-foreground/30 text-foreground hover:bg-secondary',
+			info: 'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-900/40',
 			success:
 				'border border-green-500 text-green-600 hover:bg-green-50 dark:text-green-300 dark:hover:bg-green-900/40',
 			warning:
@@ -70,7 +72,7 @@
 	onclick={onClick}
 	{disabled}
 	aria-label={ariaLabel}
-	class={`flex items-center rounded-md transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${SIZE_MAP[size]} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
+	class={`flex items-center rounded-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary ${SIZE_MAP[size]} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
 	{...rest}
 >
 	{@render children?.()}

--- a/src/lib/ui/Button.svelte
+++ b/src/lib/ui/Button.svelte
@@ -35,8 +35,8 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-primary text-foreground hover:bg-secondary',
-			secondary: 'bg-secondary text-foreground hover:opacity-90',
+			primary: 'bg-primary text-foreground border border-foreground/20 hover:bg-secondary',
+			secondary: 'bg-secondary text-foreground border border-foreground/20 hover:opacity-90',
 			info: 'bg-blue-600 text-white hover:bg-blue-700',
 			success: 'bg-green-600 text-white hover:bg-green-700',
 			warning: 'bg-orange-500 text-white hover:bg-orange-600',

--- a/src/lib/ui/Card.svelte
+++ b/src/lib/ui/Card.svelte
@@ -46,7 +46,9 @@
 	const contentPadding = $derived(PADDING_MAP[padding]);
 	const isInteractive = $derived(as === 'a' && Boolean(href));
 	const interactiveClass = $derived(
-		isInteractive ? 'block hover:shadow-md transition-shadow focus:ring-2 focus:ring-blue-500' : ''
+		isInteractive
+			? 'block hover:shadow-md transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary'
+			: ''
 	);
 
 	const showHeader = $derived(Boolean(header || title || subtitle));

--- a/src/lib/ui/Checkbox.svelte
+++ b/src/lib/ui/Checkbox.svelte
@@ -40,7 +40,7 @@
 		type="checkbox"
 		bind:checked
 		onchange={onChange}
-		class="mt-0.5 w-4 h-4 rounded text-blue-600 bg-secondary border-foreground/30 focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+		class="mt-0.5 w-5 h-5 rounded accent-foreground bg-secondary border-foreground/30 focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary focus:ring-foreground cursor-pointer disabled:cursor-not-allowed"
 	/>
 	<span class="flex flex-col">
 		{#if label}<span class="text-sm">{label}</span>{/if}

--- a/src/lib/ui/Chip.svelte
+++ b/src/lib/ui/Chip.svelte
@@ -33,7 +33,9 @@
 		md: 'text-sm px-3 py-1'
 	};
 
-	const activeRing = $derived(active ? 'ring-2 ring-blue-500' : '');
+	const activeRing = $derived(
+		active ? 'ring-2 ring-foreground ring-offset-2 ring-offset-primary' : ''
+	);
 </script>
 
 {#if onClick}
@@ -42,7 +44,7 @@
 		onclick={onClick}
 		aria-label={ariaLabel}
 		aria-pressed={active}
-		class={`inline-flex items-center gap-1 rounded-full font-medium cursor-pointer transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-blue-500 ${COLOR_MAP[color]} ${SIZE_MAP[size]} ${activeRing} ${clazz}`}
+		class={`inline-flex items-center gap-1 rounded-full font-medium cursor-pointer transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary ${COLOR_MAP[color]} ${SIZE_MAP[size]} ${activeRing} ${clazz}`}
 	>
 		{@render children?.()}
 	</button>

--- a/src/lib/ui/Collapsible.svelte
+++ b/src/lib/ui/Collapsible.svelte
@@ -28,7 +28,7 @@
 		type="button"
 		onclick={toggle}
 		aria-expanded={isOpen}
-		class="flex w-full items-center justify-between gap-2 p-3 text-left cursor-pointer hover:bg-secondary focus:outline-none focus:bg-secondary"
+		class="flex w-full items-center justify-between gap-2 p-3 text-left cursor-pointer hover:bg-secondary focus:outline-none focus:bg-secondary focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
 	>
 		<span class="font-semibold">{title}</span>
 		<span

--- a/src/lib/ui/IconButton.svelte
+++ b/src/lib/ui/IconButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	type Variant = 'solid' | 'subtle' | 'outline' | 'ghost';
-	type Color = 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
+	type Color = 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'danger';
 	type Size = 'xs' | 'sm' | 'md' | 'lg';
 
 	interface Props {
@@ -38,15 +38,17 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-blue-600 text-white hover:bg-blue-700',
-			secondary: 'bg-primary text-foreground hover:bg-secondary',
+			primary: 'bg-primary text-foreground hover:bg-secondary',
+			secondary: 'bg-secondary text-foreground hover:opacity-90',
+			info: 'bg-blue-600 text-white hover:bg-blue-700',
 			success: 'bg-green-600 text-white hover:bg-green-700',
 			warning: 'bg-orange-500 text-white hover:bg-orange-600',
 			danger: 'bg-red-600 text-white hover:bg-red-700'
 		},
 		subtle: {
-			primary: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100',
+			primary: 'bg-primary text-foreground hover:opacity-80',
 			secondary: 'bg-secondary text-foreground hover:opacity-80',
+			info: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100',
 			success:
 				'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900 dark:text-green-100',
 			warning:
@@ -54,15 +56,17 @@
 			danger: 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-100'
 		},
 		outline: {
-			primary: 'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300',
+			primary: 'border border-foreground/40 text-foreground hover:bg-primary',
 			secondary: 'border border-foreground/30 text-foreground hover:bg-secondary',
+			info: 'border border-blue-500 text-blue-600 hover:bg-blue-50 dark:text-blue-300',
 			success: 'border border-green-500 text-green-600 hover:bg-green-50 dark:text-green-300',
 			warning: 'border border-orange-500 text-orange-600 hover:bg-orange-50 dark:text-orange-300',
 			danger: 'border border-red-500 text-red-600 hover:bg-red-50 dark:text-red-300'
 		},
 		ghost: {
-			primary: 'text-blue-600 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/40',
+			primary: 'text-foreground hover:bg-primary',
 			secondary: 'text-foreground hover:bg-secondary',
+			info: 'text-blue-600 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900/40',
 			success: 'text-green-600 hover:bg-green-100 dark:text-green-300 dark:hover:bg-green-900/40',
 			warning:
 				'text-orange-600 hover:bg-orange-100 dark:text-orange-300 dark:hover:bg-orange-900/40',
@@ -76,7 +80,7 @@
 	onclick={onClick}
 	{disabled}
 	aria-label={ariaLabel}
-	class={`inline-flex items-center justify-center transition focus:outline-none focus:ring-2 focus:ring-blue-500 ${SIZE_MAP[size]} ${rounded === 'full' ? 'rounded-full' : 'rounded-md'} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
+	class={`inline-flex items-center justify-center transition focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-primary ${SIZE_MAP[size]} ${rounded === 'full' ? 'rounded-full' : 'rounded-md'} ${STYLES[variant][color]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} ${clazz}`}
 	{...rest}
 >
 	{@render children?.()}

--- a/src/lib/ui/IconButton.svelte
+++ b/src/lib/ui/IconButton.svelte
@@ -38,8 +38,8 @@
 
 	const STYLES: Record<Variant, Record<Color, string>> = {
 		solid: {
-			primary: 'bg-primary text-foreground hover:bg-secondary',
-			secondary: 'bg-secondary text-foreground hover:opacity-90',
+			primary: 'bg-primary text-foreground border border-foreground/20 hover:bg-secondary',
+			secondary: 'bg-secondary text-foreground border border-foreground/20 hover:opacity-90',
 			info: 'bg-blue-600 text-white hover:bg-blue-700',
 			success: 'bg-green-600 text-white hover:bg-green-700',
 			warning: 'bg-orange-500 text-white hover:bg-orange-600',

--- a/src/lib/ui/Input.svelte
+++ b/src/lib/ui/Input.svelte
@@ -68,7 +68,7 @@
 		onchange={onChange}
 		aria-invalid={hasError}
 		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
-		class={`border-0 rounded-lg block placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none ${SIZE_MAP[size]} ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+		class={`rounded-lg block placeholder-foreground-secondary w-full bg-secondary border focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary focus:outline-none ${SIZE_MAP[size]} ${hasError ? 'border-red-500 ring-1 ring-red-500 focus:ring-red-500' : 'border-foreground/40 focus:ring-foreground focus:border-foreground'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
 	/>
 
 	{#if hasError}

--- a/src/lib/ui/Radio.svelte
+++ b/src/lib/ui/Radio.svelte
@@ -40,7 +40,7 @@
 		type="radio"
 		bind:group
 		onchange={onChange}
-		class="mt-0.5 w-4 h-4 text-blue-600 bg-secondary border-foreground/30 focus:ring-2 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+		class="mt-0.5 w-5 h-5 accent-foreground bg-secondary border-foreground/30 focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary focus:ring-foreground cursor-pointer disabled:cursor-not-allowed"
 	/>
 	<span class="flex flex-col">
 		{#if label}<span class="text-sm">{label}</span>{/if}

--- a/src/lib/ui/Textarea.svelte
+++ b/src/lib/ui/Textarea.svelte
@@ -68,7 +68,7 @@
 		onchange={onChange}
 		aria-invalid={hasError}
 		aria-describedby={hasError ? `${fieldId}-error` : hint ? `${fieldId}-hint` : undefined}
-		class={`border-0 rounded-lg block placeholder-foreground-secondary w-full bg-secondary focus:ring-2 focus:outline-none resize-y ${SIZE_MAP[size]} ${hasError ? 'ring-2 ring-red-500 focus:ring-red-500' : 'focus:ring-blue-500'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+		class={`rounded-lg block placeholder-foreground-secondary w-full bg-secondary border focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary focus:outline-none resize-y ${SIZE_MAP[size]} ${hasError ? 'border-red-500 ring-1 ring-red-500 focus:ring-red-500' : 'border-foreground/40 focus:ring-foreground focus:border-foreground'} ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
 	></textarea>
 
 	{#if hasError}

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -304,6 +304,7 @@
 								<th class="px-2 py-1"></th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">primary</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">secondary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">info</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">success</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">warning</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">danger</th>
@@ -317,6 +318,9 @@
 								</td>
 								<td class="px-2 py-1">
 									<Button color="secondary" onClick={() => showToast('info')}>Action</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button color="info" onClick={() => showToast('info')}>Info</Button>
 								</td>
 								<td class="px-2 py-1">
 									<Button color="success" onClick={() => showToast('success')}>Save</Button>
@@ -338,6 +342,11 @@
 								<td class="px-2 py-1">
 									<Button variant="subtle" color="secondary" onClick={() => showToast('info')}>
 										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="subtle" color="info" onClick={() => showToast('info')}>
+										Info
 									</Button>
 								</td>
 								<td class="px-2 py-1">
@@ -366,6 +375,11 @@
 								<td class="px-2 py-1">
 									<Button variant="outline" color="secondary" onClick={() => showToast('info')}>
 										Action
+									</Button>
+								</td>
+								<td class="px-2 py-1">
+									<Button variant="outline" color="info" onClick={() => showToast('info')}>
+										Info
 									</Button>
 								</td>
 								<td class="px-2 py-1">
@@ -425,7 +439,7 @@
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Button variant="solid | subtle | outline"\n        color="primary | secondary | success | warning | danger"\n        size="sm | md | lg"\n        disabled\n        onClick={fn}>...</Button>'}</code
+					>{'<Button variant="solid | subtle | outline"\n        color="primary | secondary | info | success | warning | danger"\n        size="sm | md | lg"\n        disabled\n        onClick={fn}>...</Button>'}</code
 				></pre>
 		</CardShadow>
 	</section>
@@ -543,7 +557,7 @@
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<IconButton variant="ghost | subtle | outline | solid"\n            color="primary | secondary | success | warning | danger"\n            size="xs | sm | md | lg"\n            rounded="md | full"\n            ariaLabel="…"\n            onClick={fn}>\n  <Icon size="sm" />\n</IconButton>'}</code
+					>{'<IconButton variant="ghost | subtle | outline | solid"\n            color="primary | secondary | info | success | warning | danger"\n            size="xs | sm | md | lg"\n            rounded="md | full"\n            ariaLabel="…"\n            onClick={fn}>\n  <Icon size="sm" />\n</IconButton>'}</code
 				></pre>
 		</CardShadow>
 	</section>
@@ -563,6 +577,7 @@
 								<th class="px-2 py-1"></th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">primary</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">secondary</th>
+								<th class="px-2 py-1 font-normal text-xs opacity-75">info</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">success</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">warning</th>
 								<th class="px-2 py-1 font-normal text-xs opacity-75">danger</th>
@@ -573,6 +588,7 @@
 								<td class="px-2 py-1 text-xs opacity-75">solid</td>
 								<td class="px-2 py-1"><Badge variant="solid" color="primary">New</Badge></td>
 								<td class="px-2 py-1"><Badge variant="solid" color="secondary">Default</Badge></td>
+								<td class="px-2 py-1"><Badge variant="solid" color="info">Info</Badge></td>
 								<td class="px-2 py-1"><Badge variant="solid" color="success">Done</Badge></td>
 								<td class="px-2 py-1"><Badge variant="solid" color="warning">Hold</Badge></td>
 								<td class="px-2 py-1"><Badge variant="solid" color="danger">Fail</Badge></td>
@@ -581,6 +597,7 @@
 								<td class="px-2 py-1 text-xs opacity-75">subtle</td>
 								<td class="px-2 py-1"><Badge variant="subtle" color="primary">New</Badge></td>
 								<td class="px-2 py-1"><Badge variant="subtle" color="secondary">Default</Badge></td>
+								<td class="px-2 py-1"><Badge variant="subtle" color="info">Info</Badge></td>
 								<td class="px-2 py-1"><Badge variant="subtle" color="success">Done</Badge></td>
 								<td class="px-2 py-1"><Badge variant="subtle" color="warning">Hold</Badge></td>
 								<td class="px-2 py-1"><Badge variant="subtle" color="danger">Fail</Badge></td>
@@ -590,6 +607,7 @@
 								<td class="px-2 py-1"><Badge variant="outline" color="primary">New</Badge></td>
 								<td class="px-2 py-1"><Badge variant="outline" color="secondary">Default</Badge></td
 								>
+								<td class="px-2 py-1"><Badge variant="outline" color="info">Info</Badge></td>
 								<td class="px-2 py-1"><Badge variant="outline" color="success">Done</Badge></td>
 								<td class="px-2 py-1"><Badge variant="outline" color="warning">Hold</Badge></td>
 								<td class="px-2 py-1"><Badge variant="outline" color="danger">Fail</Badge></td>
@@ -627,7 +645,7 @@
 			</div>
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
-					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | success | warning | danger"\n       size="sm | md | lg">label</Badge>'}</code
+					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | info | success | warning | danger"\n       size="sm | md | lg">label</Badge>'}</code
 				></pre>
 		</CardShadow>
 	</section>


### PR DESCRIPTION
Address design-system feedback:

- Pastel theme contrast: darken --color-foreground-secondary so hint
  text on bg-primary passes WCAG AA. Fix THEMES constant entry so the
  pastel swatch in /design-system actually shows the foreground.
- Pinky / Violet themes: rework palettes so foreground/background pairs
  meet AA contrast (previously violet 2.6:1, pinky 3.3:1 — both failing).
- Button / IconButton / Badge: redefine color="primary" and "secondary"
  to use the theme tokens (bg-primary/bg-secondary, text-foreground)
  instead of hard-coded blue. Add a new color="info" for the blue
  variant and update the design-system matrices and snippet docs.
- Focus rings: add ring-offset-2 with ring-offset-primary, and switch
  from hard-coded ring-blue-500 to theme-aware ring-foreground so the
  indicator stays high-contrast across every theme. Move to
  focus-visible: where keyboard-only behavior is appropriate.
- Input / Textarea: keep a visible border (border-foreground/40) in the
  non-focus state, with red border on error.
- Checkbox / Radio: bump from w-4/h-4 to w-5/h-5 (better target size)
  and use accent-foreground so the check/dot follows the active theme.