### PR TITLE
feat(adhkar): add /adhkar morning & evening dhikr checklist

### DIFF
--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,5 +1,6 @@
 export const staticUrls = [
 	'/about',
+	'/adhkar',
 	'/all-surah',
 	'/asmaul-husna',
 	'/ayat-kursi',

--- a/src/data/adhkar.ts
+++ b/src/data/adhkar.ts
@@ -1,0 +1,253 @@
+export type AdhkarPeriod = 'morning' | 'evening';
+
+export interface AdhkarItem {
+	id: string;
+	period: AdhkarPeriod;
+	order: number;
+	arabic: string;
+	latin: string;
+	translation: string;
+	translationEn: string;
+	count: number;
+	source: string;
+	note?: string;
+	noteEn?: string;
+}
+
+export const ADHKAR: readonly AdhkarItem[] = [
+	{
+		id: 'm-ayat-kursi',
+		period: 'morning',
+		order: 1,
+		arabic:
+			'اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ ۚ لَا تَأْخُذُهُ سِنَةٌ وَلَا نَوْمٌ ۚ لَهُ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ ۗ مَنْ ذَا الَّذِي يَشْفَعُ عِنْدَهُ إِلَّا بِإِذْنِهِ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَيْءٍ مِنْ عِلْمِهِ إِلَّا بِمَا شَاءَ ۚ وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَالْأَرْضَ ۖ وَلَا يَئُودُهُ حِفْظُهُمَا ۚ وَهُوَ الْعَلِيُّ الْعَظِيمُ',
+		latin:
+			"Allāhu lā ilāha illā huwa, al-ḥayyul-qayyūm. Lā ta'khużuhū sinatuw wa lā naum. Lahū mā fis-samāwāti wa mā fil-arḍ. Man żallażī yasyfa'u 'indahū illā bi-iżnih. Ya'lamu mā baina aidīhim wa mā khalfahum, wa lā yuḥīṭūna bisyai'im min 'ilmihī illā bimā syā'. Wasi'a kursiyyuhus-samāwāti wal-arḍ, wa lā ya'ūduhū ḥifẓuhumā, wa huwal-'aliyyul-'aẓīm.",
+		translation:
+			'Allah, tidak ada Tuhan selain Dia, Yang Mahahidup, Yang terus-menerus mengurus (makhluk-Nya). Tidak mengantuk dan tidak tidur. Milik-Nya apa yang ada di langit dan di bumi. (QS. Al-Baqarah: 255)',
+		translationEn:
+			'The Verse of the Throne — Allah, there is no deity except Him, the Ever-Living, the Sustainer of [all] existence. Neither drowsiness overtakes Him nor sleep. To Him belongs whatever is in the heavens and whatever is on the earth. (QS. Al-Baqarah: 255)',
+		count: 1,
+		source: 'HR. Al-Hakim & An-Nasa’i (shahih)',
+		note: 'Barangsiapa membacanya ketika pagi, dilindungi dari (gangguan) jin sampai sore.',
+		noteEn: 'Whoever recites it in the morning is protected from jinn until evening.'
+	},
+	{
+		id: 'm-al-ikhlas-falaq-nas',
+		period: 'morning',
+		order: 2,
+		arabic:
+			'قُلْ هُوَ اللَّهُ أَحَدٌ • قُلْ أَعُوذُ بِرَبِّ الْفَلَقِ • قُلْ أَعُوذُ بِرَبِّ النَّاسِ',
+		latin: 'Qul huwallāhu aḥad… • Qul a’ūżu birabbil-falaq… • Qul a’ūżu birabbin-nās…',
+		translation:
+			'Surat Al-Ikhlas, Al-Falaq, dan An-Nas. Dibaca tiga kali, mencukupi seseorang dari segala sesuatu.',
+		translationEn:
+			'Recite Surah Al-Ikhlas, Al-Falaq, and An-Nas — three times each suffices a person from everything.',
+		count: 3,
+		source: 'HR. Abu Dawud & At-Tirmidzi (shahih)'
+	},
+	{
+		id: 'm-sayyidul-istighfar',
+		period: 'morning',
+		order: 3,
+		arabic:
+			'اللَّهُمَّ أَنْتَ رَبِّي لَا إِلَهَ إِلَّا أَنْتَ، خَلَقْتَنِي وَأَنَا عَبْدُكَ، وَأَنَا عَلَى عَهْدِكَ وَوَعْدِكَ مَا اسْتَطَعْتُ، أَعُوذُ بِكَ مِنْ شَرِّ مَا صَنَعْتُ، أَبُوءُ لَكَ بِنِعْمَتِكَ عَلَيَّ، وَأَبُوءُ بِذَنْبِي، فَاغْفِرْ لِي، فَإِنَّهُ لَا يَغْفِرُ الذُّنُوبَ إِلَّا أَنْتَ',
+		latin:
+			"Allāhumma anta rabbī lā ilāha illā anta, khalaqtanī wa anā 'abduka, wa anā 'alā 'ahdika wa wa'dika mastaṭa'tu, a'ūżu bika min syarri mā ṣana'tu, abū'u laka bi-ni'matika 'alayya, wa abū'u biżanbī, fagfir lī, fa-innahū lā yagfiruż-żunūba illā anta.",
+		translation:
+			'Ya Allah, Engkau Tuhanku, tidak ada tuhan selain Engkau. Engkau menciptakanku dan aku hamba-Mu… Ampunilah aku, sesungguhnya tidak ada yang mengampuni dosa kecuali Engkau.',
+		translationEn:
+			'O Allah, You are my Lord, there is no god but You. You created me and I am Your servant… So forgive me, for none forgives sins but You.',
+		count: 1,
+		source: 'HR. Al-Bukhari',
+		note: 'Sayyidul Istighfar — penghulu istighfar.',
+		noteEn: 'The chief of supplications for forgiveness.'
+	},
+	{
+		id: 'm-asbahna',
+		period: 'morning',
+		order: 4,
+		arabic:
+			'أَصْبَحْنَا وَأَصْبَحَ الْمُلْكُ لِلَّهِ، وَالْحَمْدُ لِلَّهِ، لَا إِلَهَ إِلَّا اللَّهُ وَحْدَهُ لَا شَرِيكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيرٌ',
+		latin:
+			"Aṣbaḥnā wa aṣbaḥal-mulku lillāh, walḥamdu lillāh, lā ilāha illallāhu waḥdahū lā syarīka lah, lahul-mulku wa lahul-ḥamdu wa huwa 'alā kulli syai'in qadīr.",
+		translation:
+			'Kami telah memasuki waktu pagi dan kerajaan hanyalah milik Allah, segala puji bagi Allah. Tidak ada tuhan selain Allah Yang Maha Esa, tidak ada sekutu bagi-Nya.',
+		translationEn:
+			'We have entered the morning and the dominion belongs to Allah; all praise is for Allah. There is no god but Allah, alone, with no partner.',
+		count: 1,
+		source: 'HR. Muslim'
+	},
+	{
+		id: 'm-bismillah',
+		period: 'morning',
+		order: 5,
+		arabic:
+			'بِسْمِ اللَّهِ الَّذِي لَا يَضُرُّ مَعَ اسْمِهِ شَيْءٌ فِي الْأَرْضِ وَلَا فِي السَّمَاءِ وَهُوَ السَّمِيعُ الْعَلِيمُ',
+		latin:
+			"Bismillāhillażī lā yaḍurru ma'asmihī syai'un fil-arḍi wa lā fis-samā'i wa huwas-samī'ul-'alīm.",
+		translation:
+			'Dengan nama Allah yang dengan menyebut nama-Nya tidak akan ada sesuatu pun di bumi maupun di langit yang membahayakan. Dia Maha Mendengar lagi Maha Mengetahui.',
+		translationEn:
+			'In the name of Allah, with whose name nothing on earth or in heaven can cause harm — He is the All-Hearing, the All-Knowing.',
+		count: 3,
+		source: 'HR. Abu Dawud & At-Tirmidzi (shahih)'
+	},
+	{
+		id: 'm-radhitu',
+		period: 'morning',
+		order: 6,
+		arabic:
+			'رَضِيتُ بِاللَّهِ رَبًّا، وَبِالْإِسْلَامِ دِينًا، وَبِمُحَمَّدٍ صَلَّى اللَّهُ عَلَيْهِ وَسَلَّمَ نَبِيًّا',
+		latin:
+			"Raḍītu billāhi rabbā, wa bil-islāmi dīnā, wa bi-Muḥammadin ṣallallāhu 'alaihi wa sallama nabiyyā.",
+		translation: 'Aku ridha Allah sebagai Tuhan, Islam sebagai agama, dan Muhammad ﷺ sebagai Nabi.',
+		translationEn:
+			'I am pleased with Allah as my Lord, Islam as my religion, and Muhammad ﷺ as my Prophet.',
+		count: 3,
+		source: 'HR. Abu Dawud & At-Tirmidzi (hasan shahih)'
+	},
+	{
+		id: 'm-hasbiyallah',
+		period: 'morning',
+		order: 7,
+		arabic:
+			'حَسْبِيَ اللَّهُ لَا إِلَهَ إِلَّا هُوَ عَلَيْهِ تَوَكَّلْتُ وَهُوَ رَبُّ الْعَرْشِ الْعَظِيمِ',
+		latin: "Ḥasbiyallāhu lā ilāha illā huwa, 'alaihi tawakkaltu wa huwa rabbul-'arsyil-'aẓīm.",
+		translation:
+			'Cukuplah Allah bagiku, tidak ada Tuhan selain Dia. Hanya kepada-Nya aku bertawakal, dan Dia Tuhan pemilik Arsy yang agung.',
+		translationEn:
+			'Allah is sufficient for me. There is no god but Him. I rely upon Him, and He is the Lord of the Great Throne.',
+		count: 7,
+		source: 'HR. Abu Dawud (hasan)'
+	},
+	{
+		id: 'm-subhanallah-wa-bihamdihi',
+		period: 'morning',
+		order: 8,
+		arabic: 'سُبْحَانَ اللَّهِ وَبِحَمْدِهِ',
+		latin: 'Subḥānallāhi wa biḥamdih.',
+		translation: 'Mahasuci Allah, dan dengan memuji-Nya.',
+		translationEn: 'Glory to Allah and praise be to Him.',
+		count: 100,
+		source: 'HR. Al-Bukhari & Muslim',
+		note: 'Siapa membacanya 100x dalam sehari, terhapus dosa-dosanya meski sebanyak buih di lautan.',
+		noteEn:
+			'Whoever recites it 100 times daily, his sins are forgiven though they be as much as the foam of the sea.'
+	},
+	// EVENING
+	{
+		id: 'e-ayat-kursi',
+		period: 'evening',
+		order: 1,
+		arabic:
+			'اللَّهُ لَا إِلَٰهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ ۚ لَا تَأْخُذُهُ سِنَةٌ وَلَا نَوْمٌ ۚ لَهُ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ ۗ مَنْ ذَا الَّذِي يَشْفَعُ عِنْدَهُ إِلَّا بِإِذْنِهِ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَيْءٍ مِنْ عِلْمِهِ إِلَّا بِمَا شَاءَ ۚ وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَالْأَرْضَ ۖ وَلَا يَئُودُهُ حِفْظُهُمَا ۚ وَهُوَ الْعَلِيُّ الْعَظِيمُ',
+		latin:
+			"Allāhu lā ilāha illā huwa, al-ḥayyul-qayyūm. Lā ta'khużuhū sinatuw wa lā naum. (QS. Al-Baqarah: 255)",
+		translation:
+			'Ayat Kursi. Barangsiapa membacanya di petang hari, dilindungi dari (gangguan) jin hingga pagi.',
+		translationEn:
+			'The Verse of the Throne. Whoever recites it in the evening is protected from jinn until morning.',
+		count: 1,
+		source: 'HR. Al-Hakim & An-Nasa’i (shahih)'
+	},
+	{
+		id: 'e-al-ikhlas-falaq-nas',
+		period: 'evening',
+		order: 2,
+		arabic:
+			'قُلْ هُوَ اللَّهُ أَحَدٌ • قُلْ أَعُوذُ بِرَبِّ الْفَلَقِ • قُلْ أَعُوذُ بِرَبِّ النَّاسِ',
+		latin: 'Qul huwallāhu aḥad… • Qul a’ūżu birabbil-falaq… • Qul a’ūżu birabbin-nās…',
+		translation:
+			'Surat Al-Ikhlas, Al-Falaq, dan An-Nas. Dibaca tiga kali, mencukupi seseorang dari segala sesuatu.',
+		translationEn:
+			'Surahs Al-Ikhlas, Al-Falaq, and An-Nas — three times each suffices a person from everything.',
+		count: 3,
+		source: 'HR. Abu Dawud & At-Tirmidzi (shahih)'
+	},
+	{
+		id: 'e-sayyidul-istighfar',
+		period: 'evening',
+		order: 3,
+		arabic:
+			'اللَّهُمَّ أَنْتَ رَبِّي لَا إِلَهَ إِلَّا أَنْتَ، خَلَقْتَنِي وَأَنَا عَبْدُكَ، وَأَنَا عَلَى عَهْدِكَ وَوَعْدِكَ مَا اسْتَطَعْتُ، أَعُوذُ بِكَ مِنْ شَرِّ مَا صَنَعْتُ، أَبُوءُ لَكَ بِنِعْمَتِكَ عَلَيَّ، وَأَبُوءُ بِذَنْبِي، فَاغْفِرْ لِي، فَإِنَّهُ لَا يَغْفِرُ الذُّنُوبَ إِلَّا أَنْتَ',
+		latin:
+			"Allāhumma anta rabbī lā ilāha illā anta, khalaqtanī wa anā 'abduka, wa anā 'alā 'ahdika wa wa'dika mastaṭa'tu, a'ūżu bika min syarri mā ṣana'tu, abū'u laka bi-ni'matika 'alayya, wa abū'u biżanbī, fagfir lī, fa-innahū lā yagfiruż-żunūba illā anta.",
+		translation: 'Sayyidul Istighfar — penghulu istighfar.',
+		translationEn: 'The chief of supplications for forgiveness.',
+		count: 1,
+		source: 'HR. Al-Bukhari'
+	},
+	{
+		id: 'e-amsayna',
+		period: 'evening',
+		order: 4,
+		arabic:
+			'أَمْسَيْنَا وَأَمْسَى الْمُلْكُ لِلَّهِ، وَالْحَمْدُ لِلَّهِ، لَا إِلَهَ إِلَّا اللَّهُ وَحْدَهُ لَا شَرِيكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيرٌ',
+		latin:
+			"Amsainā wa amsal-mulku lillāh, walḥamdu lillāh, lā ilāha illallāhu waḥdahū lā syarīka lah, lahul-mulku wa lahul-ḥamdu wa huwa 'alā kulli syai'in qadīr.",
+		translation:
+			'Kami telah memasuki waktu sore dan kerajaan hanyalah milik Allah, segala puji bagi Allah.',
+		translationEn:
+			'We have entered the evening and the dominion belongs to Allah; all praise is for Allah.',
+		count: 1,
+		source: 'HR. Muslim'
+	},
+	{
+		id: 'e-bismillah',
+		period: 'evening',
+		order: 5,
+		arabic:
+			'بِسْمِ اللَّهِ الَّذِي لَا يَضُرُّ مَعَ اسْمِهِ شَيْءٌ فِي الْأَرْضِ وَلَا فِي السَّمَاءِ وَهُوَ السَّمِيعُ الْعَلِيمُ',
+		latin:
+			"Bismillāhillażī lā yaḍurru ma'asmihī syai'un fil-arḍi wa lā fis-samā'i wa huwas-samī'ul-'alīm.",
+		translation:
+			'Dengan nama Allah, yang dengan nama-Nya tidak akan ada sesuatu pun yang membahayakan, baik di bumi maupun di langit. Dia Maha Mendengar lagi Maha Mengetahui.',
+		translationEn:
+			'In the name of Allah, with whose name nothing on earth or in heaven can cause harm — He is the All-Hearing, the All-Knowing.',
+		count: 3,
+		source: 'HR. Abu Dawud & At-Tirmidzi (shahih)'
+	},
+	{
+		id: 'e-audzu-bi-kalimatillah',
+		period: 'evening',
+		order: 6,
+		arabic: 'أَعُوذُ بِكَلِمَاتِ اللَّهِ التَّامَّاتِ مِنْ شَرِّ مَا خَلَقَ',
+		latin: "A'ūżu bikalimātillāhit-tāmmāti min syarri mā khalaq.",
+		translation:
+			'Aku berlindung dengan kalimat-kalimat Allah yang sempurna dari kejahatan apa yang Dia ciptakan.',
+		translationEn:
+			'I seek refuge in the perfect words of Allah from the evil of what He has created.',
+		count: 3,
+		source: 'HR. Muslim',
+		note: 'Khusus dibaca di waktu petang.',
+		noteEn: 'Recited specifically in the evening.'
+	},
+	{
+		id: 'e-hasbiyallah',
+		period: 'evening',
+		order: 7,
+		arabic:
+			'حَسْبِيَ اللَّهُ لَا إِلَهَ إِلَّا هُوَ عَلَيْهِ تَوَكَّلْتُ وَهُوَ رَبُّ الْعَرْشِ الْعَظِيمِ',
+		latin: "Ḥasbiyallāhu lā ilāha illā huwa, 'alaihi tawakkaltu wa huwa rabbul-'arsyil-'aẓīm.",
+		translation: 'Cukuplah Allah bagiku, tidak ada Tuhan selain Dia.',
+		translationEn: 'Allah is sufficient for me. There is no god but Him.',
+		count: 7,
+		source: 'HR. Abu Dawud (hasan)'
+	},
+	{
+		id: 'e-subhanallah-wa-bihamdihi',
+		period: 'evening',
+		order: 8,
+		arabic: 'سُبْحَانَ اللَّهِ وَبِحَمْدِهِ',
+		latin: 'Subḥānallāhi wa biḥamdih.',
+		translation: 'Mahasuci Allah, dan dengan memuji-Nya.',
+		translationEn: 'Glory to Allah and praise be to Him.',
+		count: 100,
+		source: 'HR. Al-Bukhari & Muslim'
+	}
+];
+
+export function getAdhkarFor(period: AdhkarPeriod): AdhkarItem[] {
+	return ADHKAR.filter((item) => item.period === period).sort((a, b) => a.order - b.order);
+}

--- a/src/lib/AdhkarCounter.svelte
+++ b/src/lib/AdhkarCounter.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import type { AdhkarItem } from '../data/adhkar';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import CheckCircleIcon from '$lib/icons/CheckCircleIcon.svelte';
+	import ResetIcon from '$lib/icons/ResetIcon.svelte';
+
+	interface Props {
+		item: AdhkarItem;
+		count: number;
+		soundOn: boolean;
+		onIncrement: () => void;
+		onReset: () => void;
+	}
+
+	let { item, count, soundOn, onIncrement, onReset }: Props = $props();
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+	const done = $derived(count >= item.count);
+	const translation = $derived(isEnglish ? item.translationEn : item.translation);
+	const note = $derived(isEnglish ? item.noteEn : item.note);
+
+	let audioBeepSmallRef: HTMLAudioElement | undefined = $state();
+	let audioBeepLongRef: HTMLAudioElement | undefined = $state();
+
+	function handleClick() {
+		if (done) return;
+		onIncrement();
+
+		if (soundOn) {
+			if (count + 1 >= item.count) {
+				audioBeepLongRef?.play?.();
+			} else {
+				audioBeepSmallRef?.play?.();
+			}
+		}
+
+		if (typeof window?.navigator?.vibrate !== 'undefined') {
+			if (count + 1 >= item.count) {
+				window.navigator.vibrate([400, 100, 400]);
+			} else {
+				window.navigator.vibrate([60]);
+			}
+		}
+	}
+</script>
+
+<div
+	class="relative rounded-xl overflow-hidden bg-secondary shadow p-4 flex flex-col gap-3 border-2 transition-colors {done
+		? 'border-green-500'
+		: 'border-transparent'}"
+>
+	<div class="flex items-start justify-between gap-3">
+		<div class="text-xs opacity-60 font-semibold tabular-nums">
+			{item.order}
+		</div>
+		<div class="flex items-center gap-2">
+			<span
+				class="text-xs px-2 py-0.5 rounded-full font-semibold {done
+					? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
+					: 'bg-primary text-foreground/80'}"
+			>
+				{count} / {item.count}
+			</span>
+			{#if done}
+				<CheckCircleIcon size="sm" class="w-5 h-5 text-green-500" />
+			{/if}
+		</div>
+	</div>
+
+	<p dir="rtl" lang="ar" class="font-arabic text-2xl leading-loose text-right">
+		{item.arabic}
+	</p>
+
+	<p class="text-sm italic opacity-80 leading-relaxed">{item.latin}</p>
+
+	<p class="text-sm opacity-90 leading-relaxed">{translation}</p>
+
+	{#if note}
+		<p class="text-xs opacity-60 leading-relaxed italic">{note}</p>
+	{/if}
+
+	<p class="text-xs opacity-50">
+		{isEnglish ? 'Source' : 'Sumber'}: {item.source}
+	</p>
+
+	<div class="flex items-stretch gap-2 mt-1">
+		<button
+			type="button"
+			onclick={handleClick}
+			disabled={done}
+			aria-label={done
+				? isEnglish
+					? 'Target reached'
+					: 'Target tercapai'
+				: isEnglish
+					? `Count ${item.order}, currently ${count} of ${item.count}`
+					: `Hitung ${item.order}, sekarang ${count} dari ${item.count}`}
+			class="flex-1 cursor-pointer rounded-lg px-4 py-3 text-base font-semibold border-2 transition active:scale-[0.98] {done
+				? 'bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 cursor-not-allowed'
+				: 'bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground'}"
+		>
+			{#if done}
+				{isEnglish ? '✓ Done' : '✓ Selesai'}
+			{:else}
+				{isEnglish ? `Tap to count (+1)` : 'Tekan untuk menghitung (+1)'}
+			{/if}
+		</button>
+		<button
+			type="button"
+			onclick={onReset}
+			aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
+			class="cursor-pointer rounded-lg px-3 py-2 bg-secondary border-2 border-foreground/20 hover:border-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
+		>
+			<ResetIcon size="md" />
+		</button>
+	</div>
+
+	<audio bind:this={audioBeepSmallRef} preload="auto">
+		<source src="/sounds/beep-small.mp3" type="audio/mpeg" />
+	</audio>
+	<audio bind:this={audioBeepLongRef} preload="auto">
+		<source src="/sounds/beep-long.mp3" type="audio/mpeg" />
+	</audio>
+</div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,7 +30,8 @@ export const CONSTANTS = {
 		PRAYER: 'pryr',
 		THEME: 'theme',
 		LOG_PRAYER: 'log',
-		DOA_CATEGORY: 'doa_cat'
+		DOA_CATEGORY: 'doa_cat',
+		ADHKAR_LOG: 'adhkar_log'
 	},
 	BISMILLAH: '﷽'
 };
@@ -83,6 +84,9 @@ export const META_DESC_JADWAL_SHOLAT = `Jadwal sholat sesuai lokasi 💯 gratis,
 export const META_TITLE_PENCATAT_IBADAH = `Pencatat Ibadah Digital Online dari ${TITLE_CONSTANTS.TITLE_META}`;
 export const META_DESC_PENCATAT_IBADAH = `Mulai catat ibadahmu untuk refleksi diri melalui ${TITLE_CONSTANTS.TITLE_META}. Gratis sepenuhnya, tanpa iklan, tanpa unduh, tanpa analitik, privasi aman.`;
 
+export const META_TITLE_ADHKAR = `Dzikir Pagi & Petang (al-Ma'thurat) | ${TITLE_CONSTANTS.TITLE_META}`;
+export const META_DESC_ADHKAR = `Checklist dzikir pagi dan petang lengkap dengan penghitung tiap dzikir, otomatis reset di pergantian waktu sesuai jadwal sholat. ${postfix(false)}`;
+
 export const META_TITLE_SURAH = (name: string) =>
 	`Qur'an Surat ${name} | ${TITLE_CONSTANTS.TITLE_META}`;
 export const META_DESC_SURAH = (name: string) => `Qur'an Surat ${name} ${postfix(true)}`;
@@ -122,7 +126,8 @@ export type PageVariant =
 	| 'MAKKIYAH'
 	| 'MADANIYAH'
 	| 'JADWAL_SHOLAT'
-	| 'CATAT_IBADAH';
+	| 'CATAT_IBADAH'
+	| 'ADHKAR';
 // Using translation system instead of direct language comparison
 
 export const SEO_TEXT = {
@@ -150,6 +155,8 @@ export const SEO_TEXT = {
 		'Jadwal sholat terlengkap. Langsung dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.',
 	CATAT_IBADAH:
 		'Catat ibadahmu untuk refleksi diri. Pencatat ibadah online dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.',
+	ADHKAR:
+		"Dzikir pagi dan petang (al-Ma'thurat) lengkap dengan penghitung otomatis dan reset harian. Langsung dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.",
 	SURAH_DETAIL: '',
 	AYAT_DETAIL: ''
 };

--- a/src/lib/illustrations/EveningBanner.svelte
+++ b/src/lib/illustrations/EveningBanner.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		class?: string;
+	}
+	let { class: clazz = '' }: Props = $props();
+</script>
+
+<div
+	aria-hidden="true"
+	class="relative w-full overflow-hidden rounded-xl {clazz}"
+	style="aspect-ratio: 16 / 6;"
+>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 320 120"
+		preserveAspectRatio="xMidYMid slice"
+		class="absolute inset-0 w-full h-full"
+	>
+		<defs>
+			<linearGradient id="evening-sky" x1="0" y1="0" x2="0" y2="1">
+				<stop offset="0%" stop-color="#0f172a" />
+				<stop offset="55%" stop-color="#312e81" />
+				<stop offset="100%" stop-color="#5b21b6" />
+			</linearGradient>
+		</defs>
+		<rect width="320" height="120" fill="url(#evening-sky)" />
+		<g fill="#fef9c3">
+			<circle cx="40" cy="20" r="1.2" />
+			<circle cx="78" cy="38" r="0.8" />
+			<circle cx="120" cy="14" r="1" />
+			<circle cx="200" cy="28" r="1.4" />
+			<circle cx="250" cy="18" r="0.9" />
+			<circle cx="288" cy="42" r="1.1" />
+			<circle cx="156" cy="52" r="0.7" />
+		</g>
+		<g transform="translate(58 56)" fill="#fde68a">
+			<path d="M12 0 a12 12 0 1 0 0 24 a9 9 0 1 1 0 -24 z" />
+		</g>
+		<g stroke="#1e1b4b" stroke-width="1.5" fill="none" stroke-linecap="round">
+			<line x1="245" y1="120" x2="245" y2="70" />
+			<path d="M245 70 q-12 -8 -16 -16" />
+			<path d="M245 70 q12 -8 16 -16" />
+			<path d="M245 78 q-10 -6 -14 -12" />
+			<path d="M245 78 q10 -6 14 -12" />
+			<path d="M245 86 q-8 -4 -10 -8" />
+			<path d="M245 86 q8 -4 10 -8" />
+		</g>
+		<path d="M0 110 Q 80 100 160 108 T 320 105 L 320 120 L 0 120 Z" fill="#1e1b4b" opacity="0.85" />
+	</svg>
+</div>

--- a/src/lib/illustrations/MorningBanner.svelte
+++ b/src/lib/illustrations/MorningBanner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	interface Props {
+		class?: string;
+	}
+	let { class: clazz = '' }: Props = $props();
+</script>
+
+<div
+	aria-hidden="true"
+	class="relative w-full overflow-hidden rounded-xl {clazz}"
+	style="aspect-ratio: 16 / 6;"
+>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 320 120"
+		preserveAspectRatio="xMidYMid slice"
+		class="absolute inset-0 w-full h-full"
+	>
+		<defs>
+			<linearGradient id="morning-sky" x1="0" y1="0" x2="0" y2="1">
+				<stop offset="0%" stop-color="#fde68a" />
+				<stop offset="55%" stop-color="#fb923c" />
+				<stop offset="100%" stop-color="#f97316" />
+			</linearGradient>
+			<radialGradient id="morning-sun" cx="50%" cy="50%" r="50%">
+				<stop offset="0%" stop-color="#fffbeb" />
+				<stop offset="100%" stop-color="#fcd34d" />
+			</radialGradient>
+		</defs>
+		<rect width="320" height="120" fill="url(#morning-sky)" />
+		<g opacity="0.65" stroke="#fef3c7" stroke-width="0.6" stroke-linecap="round">
+			<line x1="80" y1="20" x2="240" y2="20" />
+			<line x1="60" y1="32" x2="260" y2="32" />
+			<line x1="100" y1="44" x2="220" y2="44" />
+		</g>
+		<circle cx="160" cy="92" r="28" fill="url(#morning-sun)" />
+		<g fill="#7c2d12">
+			<path d="M52 60 q3 -4 6 0 q3 -4 6 0 q-3 2 -6 2 q-3 0 -6 -2 z" />
+			<path d="M252 50 q3 -4 6 0 q3 -4 6 0 q-3 2 -6 2 q-3 0 -6 -2 z" />
+		</g>
+		<path d="M0 100 Q 80 88 160 100 T 320 100 L 320 120 L 0 120 Z" fill="#9a3412" opacity="0.75" />
+	</svg>
+</div>

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -27,7 +27,7 @@
 		"makkiyah": "Makkiyah Surahs",
 		"madaniyah": "Madaniyah Surahs",
 		"asmaulHusna": "Asmaul Husna",
-		"ayatKursi": "Ayat al-Kursi",
+		"ayatKursi": "The Verse of the Throne",
 		"dailyDoa": "Daily Duas",
 		"tahlil": "Tahlil",
 		"wirid": "Dhikr",
@@ -40,7 +40,8 @@
 		"about": "About",
 		"ayatOfTheDay": "AyatOfTheDay",
 		"hijriCalendar": "Hijri Calendar",
-		"designSystem": "Design System"
+		"designSystem": "Design System",
+		"adhkar": "Morning & Evening Adhkar"
 	},
 	"surah": {
 		"title": "Read Quran",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -40,7 +40,8 @@
 		"about": "Tentang",
 		"ayatOfTheDay": "AyatHariIni",
 		"hijriCalendar": "Kalender Hijriyah",
-		"designSystem": "Sistem Desain"
+		"designSystem": "Sistem Desain",
+		"adhkar": "Dzikir Pagi & Petang"
 	},
 	"surah": {
 		"title": "Baca Qur'an",

--- a/src/lib/utils/adhkarPeriod.ts
+++ b/src/lib/utils/adhkarPeriod.ts
@@ -1,0 +1,51 @@
+import type { AdhkarPeriod } from '../../data/adhkar';
+import { CONSTANTS } from '../constants';
+import type { PrayerTimeResponse, PrayerTimings } from '../types';
+
+const FALLBACK_FAJR_MIN = 4 * 60;
+const FALLBACK_ASR_MIN = 15 * 60 + 30;
+const FALLBACK_ISHA_MIN = 19 * 60;
+
+function timeToMinutes(value: string | undefined): number | null {
+	if (!value) return null;
+	const cleaned = value.replace(/\s*\(.*\)\s*/, '').trim();
+	const [h, m] = cleaned.split(':').map((v) => parseInt(v, 10));
+	if (Number.isNaN(h) || Number.isNaN(m)) return null;
+	return h * 60 + m;
+}
+
+export interface AdhkarPrayerHints {
+	fajr?: string;
+	asr?: string;
+	isha?: string;
+}
+
+export function getActiveAdhkarPeriod(
+	now: Date,
+	prayerTimes: AdhkarPrayerHints | null
+): AdhkarPeriod | null {
+	const minutesNow = now.getHours() * 60 + now.getMinutes();
+	const fajr = timeToMinutes(prayerTimes?.fajr) ?? FALLBACK_FAJR_MIN;
+	const asr = timeToMinutes(prayerTimes?.asr) ?? FALLBACK_ASR_MIN;
+	const isha = timeToMinutes(prayerTimes?.isha) ?? FALLBACK_ISHA_MIN;
+
+	if (minutesNow >= fajr && minutesNow < asr) return 'morning';
+	if (minutesNow >= asr && minutesNow < isha) return 'evening';
+	if (minutesNow >= isha) return 'evening';
+	return null;
+}
+
+export function readCachedTodayTimings(): PrayerTimings | null {
+	try {
+		const raw = localStorage.getItem(CONSTANTS.STORAGE_KEY.PRAYER);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as PrayerTimeResponse;
+		const todayString = new Date()
+			.toLocaleDateString('id-ID', { month: '2-digit', day: '2-digit', year: 'numeric' })
+			.replace(/\//g, '-');
+		const today = parsed?.data?.find((d) => d.date.gregorian.date === todayString);
+		return today?.timings ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/utils/adhkarStorage.ts
+++ b/src/lib/utils/adhkarStorage.ts
@@ -1,0 +1,90 @@
+import type { AdhkarPeriod } from '../../data/adhkar';
+import { CONSTANTS } from '../constants';
+
+export type AdhkarLog = Record<string, Record<AdhkarPeriod, Record<string, number>>>;
+
+const KEY = CONSTANTS.STORAGE_KEY.ADHKAR_LOG;
+
+function safeParse(raw: string | null): AdhkarLog {
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === 'object') return parsed as AdhkarLog;
+		return {};
+	} catch {
+		return {};
+	}
+}
+
+export function loadAdhkarLog(): AdhkarLog {
+	if (typeof localStorage === 'undefined') return {};
+	return safeParse(localStorage.getItem(KEY));
+}
+
+function persist(log: AdhkarLog) {
+	if (typeof localStorage === 'undefined') return;
+	localStorage.setItem(KEY, JSON.stringify(log));
+}
+
+export function getCount(log: AdhkarLog, date: string, period: AdhkarPeriod, id: string): number {
+	return log[date]?.[period]?.[id] ?? 0;
+}
+
+export function increment(
+	log: AdhkarLog,
+	date: string,
+	period: AdhkarPeriod,
+	id: string,
+	target: number
+): AdhkarLog {
+	const day = log[date] ?? ({} as Record<AdhkarPeriod, Record<string, number>>);
+	const slot = day[period] ?? {};
+	const current = slot[id] ?? 0;
+	const next = Math.min(current + 1, target);
+	const updated: AdhkarLog = {
+		...log,
+		[date]: {
+			...day,
+			[period]: {
+				...slot,
+				[id]: next
+			}
+		} as Record<AdhkarPeriod, Record<string, number>>
+	};
+	persist(updated);
+	return updated;
+}
+
+export function reset(log: AdhkarLog, date: string, period: AdhkarPeriod, id?: string): AdhkarLog {
+	const day = log[date];
+	if (!day) return log;
+	const slot = day[period];
+	if (!slot) return log;
+	let nextSlot: Record<string, number>;
+	if (id) {
+		nextSlot = { ...slot, [id]: 0 };
+	} else {
+		nextSlot = {};
+	}
+	const updated: AdhkarLog = {
+		...log,
+		[date]: {
+			...day,
+			[period]: nextSlot
+		} as Record<AdhkarPeriod, Record<string, number>>
+	};
+	persist(updated);
+	return updated;
+}
+
+export function pruneOldDays(log: AdhkarLog, maxDays = 14): AdhkarLog {
+	const keys = Object.keys(log).sort();
+	if (keys.length <= maxDays) return log;
+	const keep = new Set(keys.slice(-maxDays));
+	const next: AdhkarLog = {};
+	for (const k of keys) {
+		if (keep.has(k)) next[k] = log[k];
+	}
+	persist(next);
+	return next;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 		{ href: '/asmaul-husna/', title: `💯 ${$t('navigation.asmaulHusna')}` },
 		{ href: '/daily-doa/', title: `🙏 ${$t('navigation.dailyDoa')}` },
 		{ href: '/wirid/', title: `🧎 ${$t('navigation.wirid')}` },
+		{ href: '/adhkar/', title: `🌅 ${$t('navigation.adhkar')}` },
 		{ href: '/tasbih/', title: `📿 ${$t('navigation.tasbih')}` },
 		{ href: '/tahlil/', title: `🤲 ${$t('navigation.tahlil')}` },
 		{ href: '/ayat-kursi/', title: `🪑 ${$t('navigation.ayatKursi')}` },

--- a/src/routes/adhkar/+page.svelte
+++ b/src/routes/adhkar/+page.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	import Breadcrumb from '$lib/Breadcrumb.svelte';
+	import MetaTag from '$lib/MetaTag.svelte';
+	import SeoText from '$lib/SeoText.svelte';
+	import AdhkarCounter from '$lib/AdhkarCounter.svelte';
+	import MorningBanner from '$lib/illustrations/MorningBanner.svelte';
+	import EveningBanner from '$lib/illustrations/EveningBanner.svelte';
+	import { META_DESC_ADHKAR, META_TITLE_ADHKAR, TITLE_CONSTANTS } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import { t } from '$lib/translations/store';
+	import SpeakerWaveIcon from '$lib/icons/SpeakerWaveIcon.svelte';
+	import SpeakerXMarkIcon from '$lib/icons/SpeakerXMarkIcon.svelte';
+	import { onMount } from 'svelte';
+	import { getAdhkarFor, type AdhkarPeriod } from '../../data/adhkar';
+	import { formatDate } from '$lib/utils/date';
+	import { getActiveAdhkarPeriod, readCachedTodayTimings } from '$lib/utils/adhkarPeriod';
+	import {
+		getCount,
+		increment,
+		loadAdhkarLog,
+		pruneOldDays,
+		reset as resetCount,
+		type AdhkarLog
+	} from '$lib/utils/adhkarStorage';
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	let period: AdhkarPeriod = $state('morning');
+	let manualOverride = $state(false);
+	let log: AdhkarLog = $state({});
+	let soundOn = $state(true);
+
+	const todayKey = $derived(formatDate(new Date().toISOString(), 'YYYYMMDD'));
+	const items = $derived(getAdhkarFor(period));
+	const completed = $derived(
+		items.filter((i) => getCount(log, todayKey, period, i.id) >= i.count).length
+	);
+	const total = $derived(items.length);
+	const allDone = $derived(total > 0 && completed === total);
+
+	function selectPeriod(next: AdhkarPeriod) {
+		period = next;
+		manualOverride = true;
+	}
+
+	function handleIncrement(id: string, target: number) {
+		log = increment(log, todayKey, period, id, target);
+	}
+
+	function handleReset(id: string) {
+		log = resetCount(log, todayKey, period, id);
+	}
+
+	function handleResetAll() {
+		log = resetCount(log, todayKey, period);
+	}
+
+	onMount(() => {
+		log = pruneOldDays(loadAdhkarLog());
+		const timings = readCachedTodayTimings();
+		const detected = getActiveAdhkarPeriod(new Date(), {
+			fajr: timings?.Fajr,
+			asr: timings?.Asr,
+			isha: timings?.Isha
+		});
+		if (detected && !manualOverride) {
+			period = detected;
+		}
+	});
+</script>
+
+<svelte:head>
+	<MetaTag
+		title={META_TITLE_ADHKAR}
+		desc={META_DESC_ADHKAR}
+		url={`${TITLE_CONSTANTS.PATH}adhkar/`}
+	/>
+</svelte:head>
+
+<div class="flex gap-2 px-4 mb-4">
+	<h1 class="text-3xl font-bold">
+		{period === 'morning' ? '🌅' : '🌙'}
+		{isEnglish ? 'Morning & Evening Adhkar' : 'Dzikir Pagi & Petang'}
+	</h1>
+</div>
+
+<div class="px-4 mb-4">
+	<Breadcrumb
+		items={[
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
+			{
+				text: isEnglish ? 'Adhkar' : 'Dzikir Pagi & Petang',
+				href: '/adhkar/'
+			}
+		]}
+	/>
+</div>
+
+<div class="px-4 flex flex-col gap-4 pb-8">
+	<div class="grid grid-cols-2 gap-2 bg-secondary p-1 rounded-xl">
+		<button
+			type="button"
+			onclick={() => selectPeriod('morning')}
+			class="rounded-lg px-3 py-2 text-sm font-semibold transition cursor-pointer {period ===
+			'morning'
+				? 'bg-primary shadow border border-foreground/20'
+				: 'opacity-70 hover:opacity-100'}"
+			aria-pressed={period === 'morning'}
+		>
+			🌅 {isEnglish ? 'Morning' : 'Pagi'}
+		</button>
+		<button
+			type="button"
+			onclick={() => selectPeriod('evening')}
+			class="rounded-lg px-3 py-2 text-sm font-semibold transition cursor-pointer {period ===
+			'evening'
+				? 'bg-primary shadow border border-foreground/20'
+				: 'opacity-70 hover:opacity-100'}"
+			aria-pressed={period === 'evening'}
+		>
+			🌙 {isEnglish ? 'Evening' : 'Petang'}
+		</button>
+	</div>
+
+	{#if period === 'morning'}
+		<MorningBanner />
+	{:else}
+		<EveningBanner />
+	{/if}
+
+	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
+		<div class="flex items-center justify-between gap-3">
+			<div>
+				<p class="text-sm opacity-70">
+					{isEnglish ? 'Progress today' : 'Progress hari ini'}
+				</p>
+				<p
+					class="font-bold text-lg tabular-nums {allDone
+						? 'text-green-600 dark:text-green-400'
+						: ''}"
+				>
+					{completed} / {total}
+					{#if allDone}
+						<span class="text-sm font-normal">— {isEnglish ? 'complete!' : 'selesai!'} 🎉</span>
+					{/if}
+				</p>
+			</div>
+			<div class="flex items-center gap-2">
+				<button
+					type="button"
+					onclick={() => (soundOn = !soundOn)}
+					aria-label={soundOn
+						? isEnglish
+							? 'Mute'
+							: 'Matikan suara'
+						: isEnglish
+							? 'Unmute'
+							: 'Hidupkan suara'}
+					class="cursor-pointer rounded-lg p-2 bg-primary border-2 border-foreground/20 hover:border-foreground/40"
+				>
+					{#if soundOn}
+						<SpeakerWaveIcon size="sm" />
+					{:else}
+						<SpeakerXMarkIcon size="sm" />
+					{/if}
+				</button>
+				<button
+					type="button"
+					onclick={handleResetAll}
+					class="cursor-pointer rounded-lg px-3 py-2 text-xs font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40"
+				>
+					{isEnglish ? 'Reset all' : 'Reset semua'}
+				</button>
+			</div>
+		</div>
+		<div class="w-full bg-primary rounded-full h-2 overflow-hidden">
+			<div
+				class="h-2 rounded-full transition-all duration-300 {allDone
+					? 'bg-green-500'
+					: 'bg-blue-500'}"
+				style="width: {total === 0 ? 0 : (completed / total) * 100}%"
+			></div>
+		</div>
+	</div>
+
+	<div class="flex flex-col gap-3">
+		{#each items as item (item.id)}
+			<AdhkarCounter
+				{item}
+				{soundOn}
+				count={getCount(log, todayKey, period, item.id)}
+				onIncrement={() => handleIncrement(item.id, item.count)}
+				onReset={() => handleReset(item.id)}
+			/>
+		{/each}
+	</div>
+</div>
+
+<SeoText variant="ADHKAR" />


### PR DESCRIPTION
Add a new route /adhkar with morning/evening adhkar (al-Ma'thurat) sets,
per-dhikr counters persisted in localStorage and keyed by date so the
list auto-resets daily. The active period is detected from the cached
prayer-time response (`STORAGE_KEY.PRAYER`) using Fajr/Asr/Isha; users
can manually switch periods.

- Add src/data/adhkar.ts with 8 morning + 8 evening dhikr (Bukhari /
  Muslim / Abu Dawud / Tirmidzi sources) and id+en translations.
- Add inline-SVG MorningBanner / EveningBanner illustrations.
- Add AdhkarCounter.svelte with tap-to-count, vibration, sound beep,
  per-row reset and check state.
- Add adhkarPeriod & adhkarStorage utils; STORAGE_KEY.ADHKAR_LOG.
- Register /adhkar in prerender + sitemap, expose from the homepage
  feature grid, and translate the new "ayatKursi" label as
  "The Verse of the Throne".

Refs #415