### PR TITLE
feat(jadwal-sholat): full redesign with countdown, date strip, hijri, and global reminder

### DIFF
--- a/src/lib/PrayerDateStrip.svelte
+++ b/src/lib/PrayerDateStrip.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import type { PrayerTimeData } from './types';
+
+	interface Props {
+		prayerTimes: PrayerTimeData[];
+		selectedIndex: number;
+		onSelect: (index: number) => void;
+	}
+
+	let { prayerTimes, selectedIndex, onSelect }: Props = $props();
+
+	const todayDate = new Date().getDate();
+
+	const WEEKDAY_SHORT: Record<string, string> = {
+		Sunday: 'Min',
+		Monday: 'Sen',
+		Tuesday: 'Sel',
+		Wednesday: 'Rab',
+		Thursday: 'Kam',
+		Friday: 'Jum',
+		Saturday: 'Sab'
+	};
+
+	let stripEl: HTMLDivElement | null = $state(null);
+
+	$effect(() => {
+		if (stripEl && selectedIndex >= 0 && selectedIndex < prayerTimes.length) {
+			const btn = stripEl.children[selectedIndex] as HTMLElement | undefined;
+			btn?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+		}
+	});
+</script>
+
+<div
+	bind:this={stripEl}
+	class="flex gap-1.5 overflow-x-auto pb-1"
+	style="scrollbar-width: none; -ms-overflow-style: none;"
+	role="listbox"
+	aria-label="Pilih tanggal"
+>
+	{#each prayerTimes as day, i}
+		{@const dayNum = parseInt(day.date.gregorian.day)}
+		{@const weekday = day.date.gregorian.weekday.en}
+		{@const isToday = dayNum === todayDate}
+		{@const isSelected = i === selectedIndex}
+		{@const isFriday = weekday === 'Friday'}
+
+		<button
+			type="button"
+			role="option"
+			aria-selected={isSelected}
+			class="flex-shrink-0 flex flex-col items-center gap-0.5 w-11 py-2 rounded-xl transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground
+				{isSelected
+				? 'bg-foreground text-primary font-bold shadow-md scale-105'
+				: isToday
+					? 'bg-secondary border-2 border-foreground/30'
+					: 'bg-secondary/50 hover:bg-secondary'}"
+			onclick={() => onSelect(i)}
+		>
+			<span class="text-[9px] uppercase tracking-wide {isSelected ? 'opacity-70' : 'opacity-50'}"
+				>{WEEKDAY_SHORT[weekday] ?? weekday.slice(0, 3)}</span
+			>
+			<span
+				class="text-base leading-none {isFriday && !isSelected
+					? 'text-green-600'
+					: isSelected
+						? 'text-primary'
+						: ''}">{dayNum}</span
+			>
+			<span
+				class="w-1 h-1 rounded-full {isSelected
+					? 'bg-primary opacity-70'
+					: isToday
+						? 'bg-foreground opacity-40'
+						: 'opacity-0'}"
+			></span>
+		</button>
+	{/each}
+</div>

--- a/src/lib/PrayerReminderBanner.svelte
+++ b/src/lib/PrayerReminderBanner.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { nextPrayerInfo, isNearPrayer } from '../store/prayerReminder';
+	import type { PrayerKey } from './types';
+
+	const PRAYER_NAMES: Record<PrayerKey, string> = {
+		Fajr: 'Subuh',
+		Dhuhr: 'Dzuhur',
+		Asr: 'Ashar',
+		Maghrib: 'Maghrib',
+		Isha: 'Isya'
+	};
+
+	const PRAYER_EMOJIS: Record<PrayerKey, string> = {
+		Fajr: '🌅',
+		Dhuhr: '☀️',
+		Asr: '🌤️',
+		Maghrib: '🌇',
+		Isha: '🌙'
+	};
+
+	let isUrgent = $derived($nextPrayerInfo !== null && $nextPrayerInfo.minutesLeft <= 5);
+</script>
+
+{#if $isNearPrayer && $nextPrayerInfo}
+	<div
+		role="alert"
+		aria-live="polite"
+		aria-label="Pengingat waktu sholat"
+		class="fixed bottom-0 left-0 right-0 z-50 pointer-events-none"
+	>
+		<div
+			class="max-w-[500px] mx-auto overflow-hidden shadow-lg {isUrgent
+				? 'bg-red-500 text-white'
+				: 'bg-amber-400 text-amber-950'}"
+		>
+			<div class="marquee-container py-2 text-sm font-semibold">
+				<div class="marquee-track whitespace-nowrap">
+					{#each [1, 2, 3] as _}
+						<span class="px-8">
+							{PRAYER_EMOJIS[$nextPrayerInfo.key]}
+							Waktu {PRAYER_NAMES[$nextPrayerInfo.key]} dalam
+							{$nextPrayerInfo.minutesLeft} menit — Siapkan dirimu untuk sholat
+						</span>
+					{/each}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.marquee-container {
+		overflow: hidden;
+	}
+
+	.marquee-track {
+		display: inline-block;
+		animation: prayer-marquee 18s linear infinite;
+	}
+
+	@keyframes prayer-marquee {
+		0% {
+			transform: translateX(0);
+		}
+		100% {
+			transform: translateX(-33.333%);
+		}
+	}
+</style>

--- a/src/lib/PrayerTimeCard.svelte
+++ b/src/lib/PrayerTimeCard.svelte
@@ -1,48 +1,93 @@
 <script lang="ts">
-	import CardShadow from './CardShadow.svelte';
 	import type { PrayerKey, PrayerTimings } from './types';
 	import { onMount } from 'svelte';
 	import { getDayjs, getDayjsFormatted, getMinuteDuration } from '$lib/utils/date';
 
-	import { activeTheme } from '../store';
+	const PRAYER_META: Record<PrayerKey, { emoji: string; arabic: string }> = {
+		Fajr: { emoji: '🌅', arabic: 'الفجر' },
+		Dhuhr: { emoji: '☀️', arabic: 'الظهر' },
+		Asr: { emoji: '🌤️', arabic: 'العصر' },
+		Maghrib: { emoji: '🌇', arabic: 'المغرب' },
+		Isha: { emoji: '🌙', arabic: 'العشاء' }
+	};
 
 	interface Props {
 		timings?: PrayerTimings | null;
 		prayerKey: PrayerKey;
 		prayerTitle: string;
+		isNext?: boolean;
+		isToday?: boolean;
 	}
 
-	let { timings = null, prayerKey, prayerTitle = '' }: Props = $props();
+	let { timings = null, prayerKey, prayerTitle, isNext = false, isToday = true }: Props = $props();
+
 	let isPast: boolean = $state(false);
 	let durationText: string = $state('');
 
-	onMount(async () => {
+	function computeState() {
+		if (!isToday || !timings?.[prayerKey]) return;
 		const now = getDayjs();
-		const timeStr = `${timings?.[prayerKey] || ''}`.substring(0, 5);
-
+		const timeStr = `${timings[prayerKey]}`.substring(0, 5);
+		if (!timeStr.includes(':')) return;
 		const prayerTime = getDayjsFormatted(
 			`${now.format('YYYY-MM-DD')} ${timeStr}`,
 			'YYYY-MM-DD HH:mm'
 		);
-
 		const diffTime = prayerTime.diff(now, 'minute');
 		isPast = diffTime < 0;
-		durationText = getMinuteDuration(diffTime);
+		if (!isPast) durationText = getMinuteDuration(diffTime);
+	}
+
+	onMount(() => {
+		computeState();
+		const id = setInterval(computeState, 30_000);
+		return () => clearInterval(id);
 	});
+
+	let meta = $derived(PRAYER_META[prayerKey]);
 </script>
 
 {#if timings}
-	<CardShadow class={`${isPast ? ($activeTheme === 'light' ? '!bg-gray-400' : 'grayscale') : ''}`}>
-		<div class="flex justify-between gap-2 relative">
-			<div>
-				<p class={`${isPast ? 'line-through' : ''}`}>{prayerTitle}</p>
-			</div>
-			<div>
-				<p class={`${isPast ? 'line-through' : ''}`}>{timings[prayerKey]}</p>
-				{#if !isPast}
-					<small>{durationText}</small>
-				{/if}
-			</div>
+	<div
+		class="relative flex items-center gap-3 px-4 py-3 rounded-xl transition-all
+			{isPast && isToday
+			? 'opacity-40 bg-secondary/30'
+			: isNext && isToday
+				? 'bg-amber-500/15 border-2 border-amber-500/50 shadow-sm'
+				: 'bg-secondary/60 hover:bg-secondary'}"
+		role="listitem"
+		aria-label="{prayerTitle}: {timings[prayerKey].substring(0, 5)}"
+	>
+		{#if isNext && isToday}
+			<span
+				class="absolute top-3 right-3 w-2 h-2 rounded-full bg-amber-500 animate-pulse"
+				aria-hidden="true"
+			></span>
+		{/if}
+
+		<span class="text-2xl select-none" aria-hidden="true">{meta.emoji}</span>
+
+		<div class="flex-1 min-w-0">
+			<p class="font-semibold text-sm leading-tight {isPast && isToday ? 'line-through' : ''}">
+				{prayerTitle}
+			</p>
+			<p class="text-xs opacity-40 font-arabic mt-0.5">{meta.arabic}</p>
 		</div>
-	</CardShadow>
+
+		<div class="text-right shrink-0">
+			<p
+				class="font-mono font-bold text-base leading-tight
+					{isPast && isToday ? 'line-through opacity-50' : isNext && isToday ? 'text-amber-600' : ''}"
+			>
+				{timings[prayerKey].substring(0, 5)}
+			</p>
+			{#if isToday}
+				{#if isPast}
+					<p class="text-xs opacity-40 mt-0.5">Sudah lewat</p>
+				{:else if durationText}
+					<p class="text-xs opacity-60 mt-0.5 {isNext ? 'text-amber-600' : ''}">{durationText}</p>
+				{/if}
+			{/if}
+		</div>
+	</div>
 {/if}

--- a/src/lib/PrayerTimeList.svelte
+++ b/src/lib/PrayerTimeList.svelte
@@ -4,37 +4,29 @@
 
 	interface Props {
 		timings?: PrayerTimings | null;
+		nextPrayerKey?: PrayerKey | null;
+		isToday?: boolean;
 	}
 
-	const PRAYER_LIST: Array<{
-		key: PrayerKey;
-		title: string;
-	}> = [
-		{
-			key: 'Fajr',
-			title: 'Subuh'
-		},
-		{
-			key: 'Dhuhr',
-			title: 'Dzuhur'
-		},
-		{
-			key: 'Asr',
-			title: 'Ashar'
-		},
-		{
-			key: 'Maghrib',
-			title: 'Maghrib'
-		},
-		{
-			key: 'Isha',
-			title: 'Isya'
-		}
+	const PRAYER_LIST: Array<{ key: PrayerKey; title: string }> = [
+		{ key: 'Fajr', title: 'Subuh' },
+		{ key: 'Dhuhr', title: 'Dzuhur' },
+		{ key: 'Asr', title: 'Ashar' },
+		{ key: 'Maghrib', title: 'Maghrib' },
+		{ key: 'Isha', title: 'Isya' }
 	];
 
-	let { timings = null }: Props = $props();
+	let { timings = null, nextPrayerKey = null, isToday = true }: Props = $props();
 </script>
 
-{#each PRAYER_LIST as prayer (prayer.key)}
-	<PrayerTimeCard {timings} prayerKey={prayer.key} prayerTitle={prayer.title} />
-{/each}
+<div class="flex flex-col gap-2" role="list" aria-label="Jadwal sholat">
+	{#each PRAYER_LIST as prayer (prayer.key)}
+		<PrayerTimeCard
+			{timings}
+			prayerKey={prayer.key}
+			prayerTitle={prayer.title}
+			isNext={prayer.key === nextPrayerKey}
+			{isToday}
+		/>
+	{/each}
+</div>

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -154,7 +154,12 @@
 		"locationSuccess": "Managed to get the latest location!",
 		"updateLocation": "Update Location",
 		"allowLocation": "Allow location access",
-		"locationUnknown": "Location not set"
+		"locationUnknown": "Location not set",
+		"nextPrayer": "Next Prayer",
+		"allDoneToday": "All prayers for today are done",
+		"pastPrayer": "Already past",
+		"todayLabel": "Today",
+		"reminderText": "{{prayer}} prayer in {{minutes}} minutes — Prepare yourself for prayer"
 	},
 	"sync": {
 		"loginSuccess": "Login successful. Welcome {{name}}!",

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -154,7 +154,12 @@
 		"locationSuccess": "Berhasil mendapatkan lokasi teranyar!",
 		"updateLocation": "Perbarui Lokasi",
 		"allowLocation": "Beri akses lokasi",
-		"locationUnknown": "Lokasi belum diketahui"
+		"locationUnknown": "Lokasi belum diketahui",
+		"nextPrayer": "Sholat Selanjutnya",
+		"allDoneToday": "Semua jadwal sholat hari ini sudah selesai",
+		"pastPrayer": "Sudah lewat",
+		"todayLabel": "Hari Ini",
+		"reminderText": "Waktu {{prayer}} dalam {{minutes}} menit — Siapkan dirimu untuk sholat"
 	},
 	"sync": {
 		"loginSuccess": "Berhasil login. Selamat datang {{name}}!",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,6 +25,9 @@
 	import VerseTafsirBottomSheet from '$lib/VerseTafsirBottomSheet.svelte';
 	import VerseShareBottomSheet from '$lib/VerseShareBottomSheet.svelte';
 	import GlobalBottomSheet from '$lib/GlobalBottomSheet.svelte';
+	import PrayerReminderBanner from '$lib/PrayerReminderBanner.svelte';
+	import { todayPrayerTimings } from '../store/prayerReminder';
+	import type { PrayerTimeData } from '$lib/types';
 	interface Props {
 		children?: import('svelte').Snippet;
 	}
@@ -97,6 +100,21 @@
 				} else {
 					settingLocation.set(null);
 				}
+
+				const storagePrayer = localStorage.getItem(CONSTANTS.STORAGE_KEY.PRAYER);
+				if (storagePrayer) {
+					const parsedPrayer = JSON.parse(storagePrayer);
+					const allTimes: PrayerTimeData[] = parsedPrayer?.data || [];
+					const todayStr = new Date()
+						.toLocaleDateString('id-ID', {
+							month: '2-digit',
+							day: '2-digit',
+							year: 'numeric'
+						})
+						.replace(/\//g, '-');
+					const todayData = allTimes.find((d) => d.date.gregorian.date === todayStr);
+					if (todayData) todayPrayerTimings.set(todayData.timings);
+				}
 			}
 		}
 	});
@@ -121,5 +139,6 @@
 		<VerseTafsirBottomSheet />
 		<VerseShareBottomSheet />
 		<GlobalBottomSheet />
+		<PrayerReminderBanner />
 	</div>
 </div>

--- a/src/routes/jadwal-sholat/+page.svelte
+++ b/src/routes/jadwal-sholat/+page.svelte
@@ -12,28 +12,71 @@
 	import Button from '$lib/ui/Button.svelte';
 	import { onMount } from 'svelte';
 	import { settingLocation } from '../../store';
-	import CardShadow from '$lib/CardShadow.svelte';
-	import type { PrayerTimeData, PrayerTimeResponse } from '$lib/types';
-	import Clock from '$lib/Clock.svelte';
+	import type { PrayerTimeData, PrayerTimeResponse, PrayerKey } from '$lib/types';
 	import { toast } from '../../store/toast';
 	import PrayerTimeList from '$lib/PrayerTimeList.svelte';
+	import PrayerDateStrip from '$lib/PrayerDateStrip.svelte';
 	import { t } from '$lib/translations/store';
 	import { t as translate } from '$lib/translations';
+	import { formatHijriDate } from '$lib/utils/hijri';
+	import { languageStore } from '$lib/checkLanguaguage';
+	import { todayPrayerTimings, nextPrayerInfo } from '../../store/prayerReminder';
 
 	const BASE_URL = 'https://api.aladhan.com/v1/calendar';
+
+	const PRAYER_NAMES: Record<PrayerKey, string> = {
+		Fajr: 'Subuh',
+		Dhuhr: 'Dzuhur',
+		Asr: 'Ashar',
+		Maghrib: 'Maghrib',
+		Isha: 'Isya'
+	};
+
+	const PRAYER_EMOJIS: Record<PrayerKey, string> = {
+		Fajr: '🌅',
+		Dhuhr: '☀️',
+		Asr: '🌤️',
+		Maghrib: '🌇',
+		Isha: '🌙'
+	};
+
 	let prayerTimes: PrayerTimeData[] = $state([]);
-	let todayPrayerTime = $derived(
-		prayerTimes.find((time) => {
-			return (
-				time.date.gregorian.date ===
-				new Date()
-					.toLocaleDateString('id-ID', { month: '2-digit', day: '2-digit', year: 'numeric' })
-					.replace(new RegExp(/\//g), '-')
-			);
-		})
+	let isLoading: boolean = $state(false);
+	let selectedIndex: number = $state(0);
+	let now: Date = $state(new Date());
+
+	const todayGregorian = new Date()
+		.toLocaleDateString('id-ID', { month: '2-digit', day: '2-digit', year: 'numeric' })
+		.replace(/\//g, '-');
+
+	let todayIndex = $derived(prayerTimes.findIndex((d) => d.date.gregorian.date === todayGregorian));
+
+	let displayedDay = $derived(prayerTimes[selectedIndex] ?? null);
+	let isViewingToday = $derived(selectedIndex === todayIndex && todayIndex >= 0);
+
+	let hours = $derived(now.getHours());
+	let minutes = $derived(now.getMinutes());
+	let seconds = $derived(now.getSeconds());
+
+	let countdownH = $derived(
+		$nextPrayerInfo ? String(Math.floor($nextPrayerInfo.secondsLeft / 3600)).padStart(2, '0') : '--'
+	);
+	let countdownM = $derived(
+		$nextPrayerInfo
+			? String(Math.floor(($nextPrayerInfo.secondsLeft % 3600) / 60)).padStart(2, '0')
+			: '--'
+	);
+	let countdownS = $derived(
+		$nextPrayerInfo ? String($nextPrayerInfo.secondsLeft % 60).padStart(2, '0') : '--'
 	);
 
-	// Source from: https://aladhan.com/prayer-times-api
+	let isCountdownUrgent = $derived($nextPrayerInfo !== null && $nextPrayerInfo.minutesLeft <= 5);
+	let isCountdownWarning = $derived(
+		$nextPrayerInfo !== null && $nextPrayerInfo.minutesLeft <= 10 && $nextPrayerInfo.minutesLeft > 5
+	);
+
+	let hijriToday = $derived(formatHijriDate(now, $languageStore));
+
 	async function refetchPrayerTime({
 		latitude,
 		longitude
@@ -43,13 +86,11 @@
 	}) {
 		const year = new Date().getFullYear();
 		const month = new Date().getMonth() + 1;
-
 		const rawResponse = await fetch(
 			`${BASE_URL}/${year}/${month}?method=15&shafaq=general&latitude=${latitude}&longitude=${longitude}`
 		);
 		const response = (await rawResponse.json()) as PrayerTimeResponse;
 		prayerTimes = response?.data || [];
-
 		localStorage.setItem(CONSTANTS.STORAGE_KEY.PRAYER, JSON.stringify(response));
 	}
 
@@ -62,22 +103,25 @@
 		longitude: number;
 		checkCache: boolean;
 	}) {
-		const fromStorage = localStorage.getItem(CONSTANTS.STORAGE_KEY.PRAYER);
-		if (checkCache && fromStorage) {
-			const parsedValue = JSON.parse(fromStorage);
-			// check current month is still the same
-			prayerTimes = parsedValue?.data || [];
-
-			const firstRow = prayerTimes[0];
-			if (firstRow) {
-				const monthFromData = firstRow.date.gregorian.month.number;
-				const currentMonth = new Date().getMonth() + 1;
-				if (monthFromData !== currentMonth) {
-					await refetchPrayerTime({ latitude, longitude });
+		isLoading = true;
+		try {
+			const fromStorage = localStorage.getItem(CONSTANTS.STORAGE_KEY.PRAYER);
+			if (checkCache && fromStorage) {
+				const parsedValue = JSON.parse(fromStorage);
+				prayerTimes = parsedValue?.data || [];
+				const firstRow = prayerTimes[0];
+				if (firstRow) {
+					const monthFromData = firstRow.date.gregorian.month.number;
+					const currentMonth = new Date().getMonth() + 1;
+					if (monthFromData !== currentMonth) {
+						await refetchPrayerTime({ latitude, longitude });
+					}
 				}
+			} else {
+				await refetchPrayerTime({ latitude, longitude });
 			}
-		} else {
-			await refetchPrayerTime({ latitude, longitude });
+		} finally {
+			isLoading = false;
 		}
 	}
 
@@ -93,9 +137,8 @@
 				`https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`
 			);
 			const res = await resRaw.json();
-			return res?.address?.city_district || '';
-		} catch (_error) {
-			console.error(`Failed get distric for lat: ${latitude}, long: ${longitude}`);
+			return res?.address?.city_district || res?.address?.suburb || res?.address?.city || '';
+		} catch {
 			return '';
 		}
 	}
@@ -137,16 +180,32 @@
 		}
 	};
 
-	onMount(async () => {
+	let initialized = false;
+	$effect(() => {
+		const ti = todayIndex;
+		if (!initialized && ti >= 0 && prayerTimes.length > 0) {
+			initialized = true;
+			selectedIndex = ti;
+			todayPrayerTimings.set(prayerTimes[ti]?.timings ?? null);
+		}
+	});
+
+	onMount(() => {
+		const clockId = setInterval(() => {
+			now = new Date();
+		}, 1000);
+
 		setTimeout(async () => {
-			if ($settingLocation?.lg && $settingLocation.lg) {
+			if ($settingLocation?.lt && $settingLocation?.lg) {
 				await fetchPrayerTime({
 					latitude: $settingLocation.lt,
 					longitude: $settingLocation.lg,
 					checkCache: true
 				});
 			}
-		}, 1000);
+		}, 500);
+
+		return () => clearInterval(clockId);
 	});
 </script>
 
@@ -158,67 +217,177 @@
 	/>
 </svelte:head>
 
-<div class="flex gap-2 px-4 mb-4">
-	<h1 class="text-3xl font-bold">
-		⏰ {$t('navigation.prayerTime')}
-	</h1>
+<div class="px-4 mb-3">
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
 </div>
 
-<div class="px-4 mb-4">
-	<Breadcrumb
-		items={[
-			{
-				text: `🏠 ${$t('navigation.home')}`,
-				href: '/'
-			}
-		]}
-	/>
+<!-- Hero: Clock + Location + Hijri date -->
+<div class="mx-4 mb-4 rounded-2xl bg-secondary overflow-hidden shadow-sm">
+	<!-- Location bar -->
+	<div class="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-foreground/10">
+		<div class="flex items-center gap-1.5 text-sm min-w-0">
+			<MarkerIcon />
+			{#if $settingLocation?.district}
+				<span class="font-medium truncate">{$settingLocation.district}</span>
+			{:else}
+				<span class="opacity-50">{$t('prayerSchedule.locationUnknown')}</span>
+			{/if}
+		</div>
+		<Button size="sm" variant="outline" onClick={getGeolocation} ariaLabel="Perbarui lokasi">
+			<MarkerIcon />
+			{$settingLocation ? $t('prayerSchedule.updateLocation') : $t('prayerSchedule.allowLocation')}
+		</Button>
+	</div>
+
+	<!-- Clock + Hijri -->
+	<div class="px-4 py-4 flex items-center justify-between gap-4">
+		<div class="flex-1 min-w-0">
+			<div class="text-4xl font-bold font-mono tabular-nums leading-none">
+				{String(hours).padStart(2, '0')}:{String(minutes).padStart(2, '0')}<span
+					class="text-2xl opacity-40">:{String(seconds).padStart(2, '0')}</span
+				>
+			</div>
+			<div class="text-sm opacity-60 mt-2">
+				{now.toLocaleDateString($languageStore === 'id' ? 'id-ID' : 'en-US', {
+					weekday: 'long',
+					day: 'numeric',
+					month: 'long',
+					year: 'numeric'
+				})}
+			</div>
+			<div class="text-xs opacity-40 mt-0.5">{hijriToday}</div>
+		</div>
+		<div class="text-5xl opacity-15 select-none shrink-0" aria-hidden="true">🕌</div>
+	</div>
 </div>
 
-<div class="px-4 flex flex-col gap-2">
-	{#if $settingLocation === null}
-		<div class="flex flex-wrap gap-2 justify-between items-center">
-			<h2 class="text-xl font-bold">
-				{$t('prayerSchedule.locationUnknown')}
-			</h2>
-			<div>
-				<Button onClick={getGeolocation}>
-					<MarkerIcon />{$t('prayerSchedule.allowLocation')}
-				</Button>
+<!-- Next prayer countdown (today only) -->
+{#if isViewingToday}
+	{#if $nextPrayerInfo}
+		<div
+			class="mx-4 mb-4 rounded-2xl overflow-hidden transition-colors
+				{isCountdownUrgent
+				? 'bg-red-500/10 border-2 border-red-500/40'
+				: isCountdownWarning
+					? 'bg-amber-500/10 border-2 border-amber-500/40'
+					: 'bg-secondary/80 border border-foreground/10'}"
+		>
+			<div class="px-4 pt-3 pb-4">
+				<p class="text-[10px] font-semibold uppercase tracking-widest opacity-50 mb-2">
+					{$t('prayerSchedule.nextPrayer')}
+				</p>
+				<div class="flex items-center gap-2 mb-3">
+					<span class="text-2xl" aria-hidden="true">{PRAYER_EMOJIS[$nextPrayerInfo.key]}</span>
+					<span class="text-lg font-bold">{PRAYER_NAMES[$nextPrayerInfo.key]}</span>
+					<span class="ml-auto font-mono text-base opacity-60">{$nextPrayerInfo.time}</span>
+				</div>
+
+				<div
+					class="flex items-end justify-center gap-1 py-1"
+					aria-label="Countdown: {countdownH} jam {countdownM} menit {countdownS} detik"
+				>
+					<div class="flex flex-col items-center min-w-[56px]">
+						<span
+							class="text-4xl font-bold font-mono tabular-nums leading-none
+								{isCountdownUrgent ? 'text-red-500' : isCountdownWarning ? 'text-amber-500' : ''}"
+							>{countdownH}</span
+						>
+						<span class="text-[9px] uppercase tracking-widest opacity-40 mt-1">jam</span>
+					</div>
+					<span class="text-3xl font-bold opacity-30 pb-3">:</span>
+					<div class="flex flex-col items-center min-w-[56px]">
+						<span
+							class="text-4xl font-bold font-mono tabular-nums leading-none
+								{isCountdownUrgent ? 'text-red-500' : isCountdownWarning ? 'text-amber-500' : ''}"
+							>{countdownM}</span
+						>
+						<span class="text-[9px] uppercase tracking-widest opacity-40 mt-1">menit</span>
+					</div>
+					<span class="text-3xl font-bold opacity-30 pb-3">:</span>
+					<div class="flex flex-col items-center min-w-[56px]">
+						<span
+							class="text-4xl font-bold font-mono tabular-nums leading-none
+								{isCountdownUrgent ? 'text-red-500' : isCountdownWarning ? 'text-amber-500' : ''}"
+							>{countdownS}</span
+						>
+						<span class="text-[9px] uppercase tracking-widest opacity-40 mt-1">detik</span>
+					</div>
+				</div>
 			</div>
 		</div>
-	{:else}
-		<div class="flex flex-wrap items-center justify-between gap-2 mb-4">
-			<div class="flex flex-col gap-2">
-				{#if $settingLocation.district}
-					<div class="flex gap-2 items-center">
-						<span>{$settingLocation.district}</span>
-					</div>
-				{/if}
-				<small>{$settingLocation.lt}, {$settingLocation.lg}</small>
-			</div>
-
-			<Button onClick={getGeolocation}>
-				<MarkerIcon />
-				{$t('prayerSchedule.updateLocation')}
-			</Button>
+	{:else if !isLoading}
+		<div
+			class="mx-4 mb-4 rounded-2xl bg-secondary/60 px-4 py-3 text-center border border-foreground/10"
+		>
+			<p class="text-sm opacity-60">✅ Semua jadwal sholat hari ini sudah selesai</p>
 		</div>
 	{/if}
+{/if}
 
-	<div class="mb-4">
-		<Clock />
+<!-- Date strip -->
+{#if prayerTimes.length > 0}
+	<div class="px-4 mb-3">
+		<PrayerDateStrip
+			{prayerTimes}
+			{selectedIndex}
+			onSelect={(i) => {
+				selectedIndex = i;
+			}}
+		/>
 	</div>
-	{#if todayPrayerTime}
-		<PrayerTimeList timings={todayPrayerTime.timings} />
-	{:else}
-		{#each [1, 2, 3, 4, 5] as item}
-			<CardShadow>
-				<div class="flex justify-between items-center gap-2" data-key={item}>
-					<span>&nbsp;</span>
-					<span>&nbsp;</span>
-				</div>
-			</CardShadow>
-		{/each}
+{/if}
+
+<!-- Selected day header -->
+{#if displayedDay}
+	<div class="px-4 mb-3 flex items-center justify-between gap-2">
+		<div>
+			<p class="text-sm font-semibold">
+				{displayedDay.date.gregorian.weekday.en.slice(0, 3)},
+				{displayedDay.date.gregorian.day}
+				{displayedDay.date.gregorian.month.en}
+				{displayedDay.date.gregorian.year}
+			</p>
+			<p class="text-xs opacity-50">
+				{displayedDay.date.hijri.day}
+				{displayedDay.date.hijri.month.en}
+				{displayedDay.date.hijri.year} H
+			</p>
+		</div>
+		{#if isViewingToday}
+			<span
+				class="text-xs px-2.5 py-1 rounded-full bg-foreground text-primary font-semibold shrink-0"
+			>
+				Hari Ini
+			</span>
+		{/if}
+	</div>
+{/if}
+
+<!-- Prayer schedule -->
+<div class="px-4 mb-6">
+	{#if $settingLocation === null && !isLoading}
+		<div class="rounded-2xl bg-secondary/50 px-6 py-10 text-center">
+			<div class="text-5xl mb-4 opacity-60" aria-hidden="true">📍</div>
+			<h2 class="font-semibold text-base mb-2">{$t('prayerSchedule.locationUnknown')}</h2>
+			<p class="text-sm opacity-60 mb-5">
+				Izinkan akses lokasi untuk mendapatkan jadwal sholat sesuai daerahmu
+			</p>
+			<Button onClick={getGeolocation} color="primary">
+				<MarkerIcon />{$t('prayerSchedule.allowLocation')}
+			</Button>
+		</div>
+	{:else if isLoading || (prayerTimes.length === 0 && $settingLocation !== null)}
+		<div class="flex flex-col gap-2" aria-label="Memuat jadwal sholat">
+			{#each [1, 2, 3, 4, 5] as _}
+				<div class="h-16 rounded-xl bg-secondary/50 animate-pulse"></div>
+			{/each}
+		</div>
+	{:else if displayedDay}
+		<PrayerTimeList
+			timings={displayedDay.timings}
+			nextPrayerKey={isViewingToday ? ($nextPrayerInfo?.key ?? null) : null}
+			isToday={isViewingToday}
+		/>
 	{/if}
 </div>
 

--- a/src/store/prayerReminder.ts
+++ b/src/store/prayerReminder.ts
@@ -1,0 +1,45 @@
+import { derived, writable, readable } from 'svelte/store';
+import type { PrayerKey, PrayerTimings } from '$lib/types';
+
+export const todayPrayerTimings = writable<PrayerTimings | null>(null);
+
+const tick = readable(new Date(), (set) => {
+	if (typeof window === 'undefined') return () => {};
+	const id = setInterval(() => set(new Date()), 1000);
+	return () => clearInterval(id);
+});
+
+const PRAYER_ORDER: PrayerKey[] = ['Fajr', 'Dhuhr', 'Asr', 'Maghrib', 'Isha'];
+
+export type NextPrayerInfo = {
+	key: PrayerKey;
+	time: string;
+	secondsLeft: number;
+	minutesLeft: number;
+};
+
+export const nextPrayerInfo = derived([todayPrayerTimings, tick], ([$timings, $now]) => {
+	if (!$timings) return null;
+
+	for (const key of PRAYER_ORDER) {
+		const timeStr = ($timings[key] || '').substring(0, 5);
+		if (!timeStr.includes(':')) continue;
+		const [h, m] = timeStr.split(':').map(Number);
+		const prayerTime = new Date($now.getFullYear(), $now.getMonth(), $now.getDate(), h, m, 0);
+		const diffMs = prayerTime.getTime() - $now.getTime();
+		if (diffMs > 0) {
+			return {
+				key,
+				time: timeStr,
+				secondsLeft: Math.floor(diffMs / 1000),
+				minutesLeft: Math.floor(diffMs / 60000)
+			} satisfies NextPrayerInfo;
+		}
+	}
+	return null;
+});
+
+export const isNearPrayer = derived(
+	nextPrayerInfo,
+	($info) => $info !== null && $info.minutesLeft <= 10
+);


### PR DESCRIPTION
- Hero card: live digital clock (HH:MM:SS), Gregorian date, and Hijri date in one glanceable panel with location bar
- Next prayer countdown card: shows next prayer emoji/name/time and a live HH:MM:SS countdown; turns amber at ≤10 min, red at ≤5 min
- Date strip: horizontal scrollable strip of all days in the current month; tapping any day shows that day's schedule with Hijri equivalents; auto-scrolls to today on load
- Prayer cards redesigned: emoji + Arabic name, past prayers show strikethrough + "Sudah lewat", next prayer highlighted in amber with pulsing dot, duration text for upcoming prayers
- Global reminder banner (PrayerReminderBanner): fixed marquee strip at the bottom of every page that appears within 10 minutes of the next prayer, turns red at ≤5 min
- prayerReminder store: derives nextPrayerInfo and isNearPrayer from cached timings + a per-second tick; initialized in layout from localStorage so banner works on any page
- Skeleton loading states and empty/no-location states handled

https://claude.ai/code/session_01VogBuyJnbEpPSmFQgnN5f1