### PR TITLE
feat(adhkar): card-stack play mode, Tabs component, celebration screen, floating mute

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-engine-strict=true
+engine-strict=false
 resolution-mode=highest

--- a/src/lib/AdhkarCounter.svelte
+++ b/src/lib/AdhkarCounter.svelte
@@ -8,14 +8,27 @@
 		item: AdhkarItem;
 		count: number;
 		soundOn: boolean;
+		playMode?: boolean;
+		isLast?: boolean;
 		onIncrement: () => void;
 		onReset: () => void;
+		onNext?: () => void;
 	}
 
-	let { item, count, soundOn, onIncrement, onReset }: Props = $props();
+	let {
+		item,
+		count,
+		soundOn,
+		playMode = false,
+		isLast = false,
+		onIncrement,
+		onReset,
+		onNext
+	}: Props = $props();
 
 	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
 	const done = $derived(count >= item.count);
+	const remaining = $derived(Math.max(0, item.count - count));
 	const translation = $derived(isEnglish ? item.translationEn : item.translation);
 	const note = $derived(isEnglish ? item.noteEn : item.note);
 
@@ -49,25 +62,65 @@
 		? 'border-green-500'
 		: 'border-transparent'}"
 >
-	<div class="flex items-start justify-between gap-3">
-		<div class="text-xs opacity-60 font-semibold tabular-nums">
-			{item.order}
-		</div>
-		<div class="flex items-center gap-2">
-			<span
-				class="text-xs px-2 py-0.5 rounded-full font-semibold {done
-					? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
-					: 'bg-primary text-foreground/80'}"
+	{#if playMode}
+		<!-- Play mode header: large order badge + count + reset -->
+		<div class="flex items-center justify-between gap-3">
+			<div class="flex items-center gap-3">
+				<div
+					class="w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl shadow-md flex-shrink-0 transition-colors {done
+						? 'bg-green-500 dark:bg-green-600 text-white'
+						: 'bg-blue-500 dark:bg-blue-600 text-white'}"
+				>
+					{item.order}
+				</div>
+				<span
+					class="text-sm px-2.5 py-1 rounded-full font-semibold tabular-nums {done
+						? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
+						: 'bg-primary text-foreground/80'}"
+				>
+					{count} / {item.count}
+				</span>
+				{#if done}
+					<CheckCircleIcon size="sm" class="text-green-500" />
+				{/if}
+			</div>
+			<button
+				type="button"
+				onclick={onReset}
+				aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
+				class="cursor-pointer rounded-lg p-1.5 bg-primary border border-foreground/10 hover:border-foreground/30 opacity-50 hover:opacity-100 transition"
 			>
-				{count} / {item.count}
-			</span>
-			{#if done}
-				<CheckCircleIcon size="sm" class="w-5 h-5 text-green-500" />
-			{/if}
+				<ResetIcon size="sm" />
+			</button>
 		</div>
-	</div>
+	{:else}
+		<!-- All-mode header: compact order + count -->
+		<div class="flex items-start justify-between gap-3">
+			<div
+				class="w-7 h-7 rounded-full bg-primary border-2 border-foreground/20 flex items-center justify-center text-xs font-bold opacity-80 flex-shrink-0"
+			>
+				{item.order}
+			</div>
+			<div class="flex items-center gap-2">
+				<span
+					class="text-xs px-2 py-0.5 rounded-full font-semibold tabular-nums {done
+						? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
+						: 'bg-primary text-foreground/80'}"
+				>
+					{count} / {item.count}
+				</span>
+				{#if done}
+					<CheckCircleIcon size="sm" class="text-green-500" />
+				{/if}
+			</div>
+		</div>
+	{/if}
 
-	<p dir="rtl" lang="ar" class="font-arabic text-2xl leading-loose text-right">
+	<p
+		dir="rtl"
+		lang="ar"
+		class="font-arabic leading-loose text-right {playMode ? 'text-3xl' : 'text-2xl'}"
+	>
 		{item.arabic}
 	</p>
 
@@ -83,37 +136,76 @@
 		{isEnglish ? 'Source' : 'Sumber'}: {item.source}
 	</p>
 
-	<div class="flex items-stretch gap-2 mt-1">
-		<button
-			type="button"
-			onclick={handleClick}
-			disabled={done}
-			aria-label={done
-				? isEnglish
-					? 'Target reached'
-					: 'Target tercapai'
-				: isEnglish
-					? `Count ${item.order}, currently ${count} of ${item.count}`
-					: `Hitung ${item.order}, sekarang ${count} dari ${item.count}`}
-			class="flex-1 cursor-pointer rounded-lg px-4 py-3 text-base font-semibold border-2 transition active:scale-[0.98] {done
-				? 'bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 cursor-not-allowed'
-				: 'bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground'}"
-		>
-			{#if done}
-				{isEnglish ? '✓ Done' : '✓ Selesai'}
+	{#if playMode}
+		<!-- Play mode action: full-width tap / next button -->
+		<div class="mt-1">
+			{#if done && !isLast}
+				<button
+					type="button"
+					onclick={onNext}
+					class="w-full cursor-pointer rounded-xl px-4 py-4 text-lg font-bold border-2 transition active:scale-[0.98] bg-blue-500 dark:bg-blue-600 text-white border-blue-600 dark:border-blue-500 hover:bg-blue-600 dark:hover:bg-blue-700 shadow-md"
+				>
+					{isEnglish ? 'Next Dhikr →' : 'Dzikir Berikutnya →'}
+				</button>
+			{:else if done && isLast}
+				<div
+					class="w-full rounded-xl px-4 py-4 text-lg font-bold border-2 bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 text-center"
+				>
+					✓ {isEnglish ? 'All Complete!' : 'Semua Selesai!'}
+				</div>
 			{:else}
-				{isEnglish ? `Tap to count (+1)` : 'Tekan untuk menghitung (+1)'}
+				<button
+					type="button"
+					onclick={handleClick}
+					aria-label={isEnglish
+						? `Count ${item.order}, ${count} of ${item.count}`
+						: `Hitung ${item.order}, ${count} dari ${item.count}`}
+					class="w-full cursor-pointer rounded-xl px-4 py-4 text-lg font-bold border-2 transition active:scale-[0.98] bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground"
+				>
+					{isEnglish ? 'Tap (+1)' : 'Tekan (+1)'}
+					{#if item.count > 1}
+						<span class="text-sm font-normal opacity-60 ml-1"
+							>({remaining}
+							{isEnglish ? 'more' : 'lagi'})</span
+						>
+					{/if}
+				</button>
 			{/if}
-		</button>
-		<button
-			type="button"
-			onclick={onReset}
-			aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
-			class="cursor-pointer rounded-lg px-3 py-2 bg-secondary border-2 border-foreground/20 hover:border-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
-		>
-			<ResetIcon size="md" />
-		</button>
-	</div>
+		</div>
+	{:else}
+		<!-- All-mode action: tap + reset buttons -->
+		<div class="flex items-stretch gap-2 mt-1">
+			<button
+				type="button"
+				onclick={handleClick}
+				disabled={done}
+				aria-label={done
+					? isEnglish
+						? 'Target reached'
+						: 'Target tercapai'
+					: isEnglish
+						? `Count ${item.order}, currently ${count} of ${item.count}`
+						: `Hitung ${item.order}, sekarang ${count} dari ${item.count}`}
+				class="flex-1 cursor-pointer rounded-lg px-4 py-3 text-base font-semibold border-2 transition active:scale-[0.98] {done
+					? 'bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 cursor-not-allowed'
+					: 'bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground'}"
+			>
+				{#if done}
+					{isEnglish ? '✓ Done' : '✓ Selesai'}
+				{:else}
+					{isEnglish ? `Tap to count (+1)` : 'Tekan untuk menghitung (+1)'}
+				{/if}
+			</button>
+			<button
+				type="button"
+				onclick={onReset}
+				aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
+				class="cursor-pointer rounded-lg px-3 py-2 bg-secondary border-2 border-foreground/20 hover:border-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
+			>
+				<ResetIcon size="md" />
+			</button>
+		</div>
+	{/if}
 
 	<audio bind:this={audioBeepSmallRef} preload="auto">
 		<source src="/sounds/beep-small.mp3" type="audio/mpeg" />

--- a/src/lib/PrayerDateStrip.svelte
+++ b/src/lib/PrayerDateStrip.svelte
@@ -33,7 +33,7 @@
 
 <div
 	bind:this={stripEl}
-	class="flex gap-1.5 overflow-x-auto pb-1"
+	class="flex gap-1.5 overflow-x-auto py-2"
 	style="scrollbar-width: none; -ms-overflow-style: none;"
 	role="listbox"
 	aria-label="Pilih tanggal"
@@ -49,7 +49,7 @@
 			type="button"
 			role="option"
 			aria-selected={isSelected}
-			class="flex-shrink-0 flex flex-col items-center gap-0.5 w-11 py-2 rounded-xl transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground
+			class="flex-shrink-0 flex flex-col items-center justify-center gap-0.5 w-11 h-12 rounded-xl transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground
 				{isSelected
 				? 'bg-foreground text-primary font-bold shadow-md scale-105'
 				: isToday

--- a/src/lib/icons/CheckCircleSolidIcon.svelte
+++ b/src/lib/icons/CheckCircleSolidIcon.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { CLASS_BY_SIZE, type IconSize } from './utils';
+
+	interface Props {
+		size?: IconSize;
+		class?: string;
+	}
+
+	let { size = 'md', class: clazz }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="currentColor"
+	class={clazz || CLASS_BY_SIZE[size]}
+>
+	<path
+		fill-rule="evenodd"
+		d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z"
+		clip-rule="evenodd"
+	/>
+</svg>

--- a/src/lib/icons/CheckIcon.svelte
+++ b/src/lib/icons/CheckIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { CLASS_BY_SIZE, type IconSize } from './utils';
+
+	interface Props {
+		size?: IconSize;
+		class?: string;
+	}
+
+	let { size = 'md', class: clazz }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width="2.5"
+	stroke="currentColor"
+	class={clazz || CLASS_BY_SIZE[size]}
+>
+	<path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+</svg>

--- a/src/lib/illustrations/PrayerTimeIllustration.svelte
+++ b/src/lib/illustrations/PrayerTimeIllustration.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+	interface Props {
+		hours: number;
+		class?: string;
+	}
+	let { hours, class: klass = '' }: Props = $props();
+
+	const period = $derived(
+		hours >= 4 && hours < 6
+			? 'fajr'
+			: hours >= 6 && hours < 12
+				? 'morning'
+				: hours >= 12 && hours < 15
+					? 'noon'
+					: hours >= 15 && hours < 18
+						? 'afternoon'
+						: hours >= 18 && hours < 20
+							? 'sunset'
+							: 'night'
+	);
+</script>
+
+<div
+	aria-hidden="true"
+	class="relative w-full overflow-hidden rounded-xl {klass}"
+	style="aspect-ratio: 16 / 6;"
+>
+	{#if period === 'fajr'}
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-fajr-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#0f172a" />
+					<stop offset="55%" stop-color="#1e3a5f" />
+					<stop offset="100%" stop-color="#c2410c" />
+				</linearGradient>
+				<radialGradient id="pt-fajr-glow" cx="50%" cy="100%" r="60%">
+					<stop offset="0%" stop-color="#fb923c" stop-opacity="0.9" />
+					<stop offset="100%" stop-color="#fb923c" stop-opacity="0" />
+				</radialGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-fajr-sky)" />
+			<!-- Dawn glow at horizon -->
+			<ellipse cx="160" cy="120" rx="160" ry="60" fill="url(#pt-fajr-glow)" />
+			<!-- Stars -->
+			<g fill="#fef9c3">
+				<circle cx="40" cy="18" r="1.2" />
+				<circle cx="82" cy="35" r="0.8" />
+				<circle cx="125" cy="12" r="1" />
+				<circle cx="198" cy="26" r="1.4" />
+				<circle cx="252" cy="16" r="0.9" />
+				<circle cx="290" cy="40" r="1.1" />
+			</g>
+			<!-- Crescent moon -->
+			<g transform="translate(58 48)" fill="#fde68a">
+				<path d="M9 0 a9 9 0 1 0 0 18 a7 7 0 1 1 0 -18 z" />
+			</g>
+			<!-- Mountain silhouette -->
+			<path
+				d="M0 90 L40 55 L70 75 L110 40 L150 70 L190 48 L230 68 L270 52 L320 75 L320 120 L0 120 Z"
+				fill="#0c1a30"
+			/>
+			<!-- Ground wave -->
+			<path d="M0 108 Q 80 98 160 106 T 320 103 L 320 120 L 0 120 Z" fill="#1a0a00" opacity="0.8" />
+		</svg>
+	{:else if period === 'morning'}
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-morning-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#fde68a" />
+					<stop offset="55%" stop-color="#fb923c" />
+					<stop offset="100%" stop-color="#f97316" />
+				</linearGradient>
+				<radialGradient id="pt-morning-sun" cx="50%" cy="50%" r="50%">
+					<stop offset="0%" stop-color="#fffbeb" />
+					<stop offset="100%" stop-color="#fcd34d" />
+				</radialGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-morning-sky)" />
+			<g opacity="0.65" stroke="#fef3c7" stroke-width="0.6" stroke-linecap="round">
+				<line x1="80" y1="20" x2="240" y2="20" />
+				<line x1="60" y1="32" x2="260" y2="32" />
+				<line x1="100" y1="44" x2="220" y2="44" />
+			</g>
+			<circle cx="160" cy="92" r="28" fill="url(#pt-morning-sun)" />
+			<g fill="#7c2d12">
+				<path d="M52 60 q3 -4 6 0 q3 -4 6 0 q-3 2 -6 2 q-3 0 -6 -2 z" />
+				<path d="M252 50 q3 -4 6 0 q3 -4 6 0 q-3 2 -6 2 q-3 0 -6 -2 z" />
+			</g>
+			<path
+				d="M0 100 Q 80 88 160 100 T 320 100 L 320 120 L 0 120 Z"
+				fill="#9a3412"
+				opacity="0.75"
+			/>
+		</svg>
+	{:else if period === 'noon'}
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-noon-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#bfdbfe" />
+					<stop offset="55%" stop-color="#60a5fa" />
+					<stop offset="100%" stop-color="#93c5fd" />
+				</linearGradient>
+				<radialGradient id="pt-noon-sun" cx="50%" cy="50%" r="50%">
+					<stop offset="0%" stop-color="#fff" />
+					<stop offset="100%" stop-color="#fde047" />
+				</radialGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-noon-sky)" />
+			<!-- Sun overhead -->
+			<circle cx="160" cy="15" r="14" fill="url(#pt-noon-sun)" />
+			<!-- Sunrays -->
+			<g stroke="#fde047" stroke-width="1.2" stroke-linecap="round" opacity="0.8">
+				<line x1="160" y1="0" x2="160" y2="-6" transform="translate(0 7)" />
+				<line x1="160" y1="15" x2="160" y2="5" transform="translate(0 -8)" />
+				<line x1="148" y1="15" x2="142" y2="9" />
+				<line x1="172" y1="15" x2="178" y2="9" />
+				<line x1="146" y1="22" x2="139" y2="18" />
+				<line x1="174" y1="22" x2="181" y2="18" />
+				<line x1="148" y1="28" x2="142" y2="34" />
+				<line x1="172" y1="28" x2="178" y2="34" />
+			</g>
+			<!-- Cloud puffs -->
+			<g fill="white" opacity="0.85">
+				<ellipse cx="80" cy="48" rx="28" ry="9" />
+				<ellipse cx="68" cy="50" rx="16" ry="8" />
+				<ellipse cx="96" cy="50" rx="16" ry="8" />
+			</g>
+			<g fill="white" opacity="0.75">
+				<ellipse cx="240" cy="55" rx="24" ry="8" />
+				<ellipse cx="228" cy="57" rx="14" ry="7" />
+				<ellipse cx="254" cy="57" rx="14" ry="7" />
+			</g>
+			<!-- Green ground wave -->
+			<path d="M0 100 Q 80 88 160 100 T 320 100 L 320 120 L 0 120 Z" fill="#166534" opacity="0.8" />
+		</svg>
+	{:else if period === 'afternoon'}
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-afternoon-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#93c5fd" />
+					<stop offset="55%" stop-color="#fde68a" />
+					<stop offset="100%" stop-color="#fb923c" />
+				</linearGradient>
+				<radialGradient id="pt-afternoon-sun" cx="50%" cy="50%" r="50%">
+					<stop offset="0%" stop-color="#fed7aa" />
+					<stop offset="100%" stop-color="#fb923c" />
+				</radialGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-afternoon-sky)" />
+			<!-- Sun lower in sky -->
+			<circle cx="220" cy="55" r="16" fill="url(#pt-afternoon-sun)" opacity="0.95" />
+			<!-- Warm clouds -->
+			<g fill="#fef3c7" opacity="0.7">
+				<ellipse cx="85" cy="42" rx="30" ry="9" />
+				<ellipse cx="72" cy="44" rx="18" ry="8" />
+				<ellipse cx="100" cy="44" rx="18" ry="8" />
+			</g>
+			<g fill="#fef3c7" opacity="0.6">
+				<ellipse cx="148" cy="68" rx="22" ry="7" />
+				<ellipse cx="136" cy="70" rx="14" ry="6" />
+				<ellipse cx="162" cy="70" rx="14" ry="6" />
+			</g>
+			<!-- Hills/ground wave -->
+			<path d="M0 100 Q 80 88 160 98 T 320 96 L 320 120 L 0 120 Z" fill="#78350f" opacity="0.8" />
+		</svg>
+	{:else if period === 'sunset'}
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-sunset-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#7f1d1d" />
+					<stop offset="35%" stop-color="#c2410c" />
+					<stop offset="70%" stop-color="#fb923c" />
+					<stop offset="100%" stop-color="#fde047" />
+				</linearGradient>
+				<radialGradient id="pt-sunset-sun" cx="50%" cy="50%" r="50%">
+					<stop offset="0%" stop-color="#fef9c3" />
+					<stop offset="100%" stop-color="#f97316" />
+				</radialGradient>
+				<radialGradient id="pt-sunset-glow" cx="50%" cy="100%" r="55%">
+					<stop offset="0%" stop-color="#fb923c" stop-opacity="0.7" />
+					<stop offset="100%" stop-color="#fb923c" stop-opacity="0" />
+				</radialGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-sunset-sky)" />
+			<!-- Horizon glow -->
+			<ellipse cx="160" cy="120" rx="180" ry="65" fill="url(#pt-sunset-glow)" />
+			<!-- Large sun at horizon -->
+			<circle cx="160" cy="105" r="32" fill="url(#pt-sunset-sun)" />
+			<!-- Mountain silhouette -->
+			<path
+				d="M0 85 L50 50 L80 68 L120 35 L160 65 L200 42 L245 62 L280 48 L320 70 L320 120 L0 120 Z"
+				fill="#1a0a00"
+			/>
+			<!-- Ground wave -->
+			<path
+				d="M0 108 Q 80 100 160 107 T 320 104 L 320 120 L 0 120 Z"
+				fill="#1a0a00"
+				opacity="0.9"
+			/>
+		</svg>
+	{:else}
+		<!-- night -->
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 320 120"
+			preserveAspectRatio="xMidYMid slice"
+			class="absolute inset-0 w-full h-full"
+		>
+			<defs>
+				<linearGradient id="pt-night-sky" x1="0" y1="0" x2="0" y2="1">
+					<stop offset="0%" stop-color="#0f172a" />
+					<stop offset="55%" stop-color="#312e81" />
+					<stop offset="100%" stop-color="#5b21b6" />
+				</linearGradient>
+			</defs>
+			<rect width="320" height="120" fill="url(#pt-night-sky)" />
+			<!-- Stars -->
+			<g fill="#fef9c3">
+				<circle cx="40" cy="20" r="1.2" />
+				<circle cx="78" cy="38" r="0.8" />
+				<circle cx="120" cy="14" r="1" />
+				<circle cx="200" cy="28" r="1.4" />
+				<circle cx="250" cy="18" r="0.9" />
+				<circle cx="288" cy="42" r="1.1" />
+				<circle cx="156" cy="52" r="0.7" />
+			</g>
+			<!-- Crescent moon -->
+			<g transform="translate(58 56)" fill="#fde68a">
+				<path d="M12 0 a12 12 0 1 0 0 24 a9 9 0 1 1 0 -24 z" />
+			</g>
+			<!-- Lantern pole -->
+			<g stroke="#1e1b4b" stroke-width="1.5" fill="none" stroke-linecap="round">
+				<line x1="245" y1="120" x2="245" y2="70" />
+				<path d="M245 70 q-12 -8 -16 -16" />
+				<path d="M245 70 q12 -8 16 -16" />
+				<path d="M245 78 q-10 -6 -14 -12" />
+				<path d="M245 78 q10 -6 14 -12" />
+				<path d="M245 86 q-8 -4 -10 -8" />
+				<path d="M245 86 q8 -4 10 -8" />
+			</g>
+			<!-- Ground wave -->
+			<path
+				d="M0 110 Q 80 100 160 108 T 320 105 L 320 120 L 0 120 Z"
+				fill="#1e1b4b"
+				opacity="0.85"
+			/>
+		</svg>
+	{/if}
+</div>

--- a/src/lib/ui/Tabs.svelte
+++ b/src/lib/ui/Tabs.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	interface TabOption {
+		value: string;
+		label: string;
+	}
+
+	interface Props {
+		options: TabOption[];
+		value: string;
+		onchange: (value: string) => void;
+		class?: string;
+	}
+
+	let { options, value, onchange, class: klass = '' }: Props = $props();
+
+	const activeIndex = $derived(options.findIndex((o) => o.value === value));
+</script>
+
+<div class="relative bg-secondary p-1 rounded-xl {klass}">
+	<!-- Sliding pill indicator -->
+	<div
+		class="absolute top-1 bottom-1 bg-primary shadow border border-foreground/20 rounded-lg pointer-events-none transition-all duration-300 ease-in-out"
+		style="left: calc(4px + {activeIndex} * (100% - 8px) / {options.length}); width: calc((100% - 8px) / {options.length});"
+		aria-hidden="true"
+	></div>
+	<!-- Tab buttons -->
+	<div class="relative grid" style="grid-template-columns: repeat({options.length}, 1fr)">
+		{#each options as option (option.value)}
+			<button
+				type="button"
+				onclick={() => onchange(option.value)}
+				class="relative z-10 rounded-lg px-3 py-2 text-sm font-semibold cursor-pointer transition-opacity duration-200 {value ===
+				option.value
+					? 'opacity-100'
+					: 'opacity-60 hover:opacity-80'}"
+				aria-pressed={value === option.value}
+			>
+				{option.label}
+			</button>
+		{/each}
+	</div>
+</div>

--- a/src/routes/adhkar/+page.svelte
+++ b/src/routes/adhkar/+page.svelte
@@ -5,11 +5,14 @@
 	import AdhkarCounter from '$lib/AdhkarCounter.svelte';
 	import MorningBanner from '$lib/illustrations/MorningBanner.svelte';
 	import EveningBanner from '$lib/illustrations/EveningBanner.svelte';
+	import Tabs from '$lib/ui/Tabs.svelte';
 	import { META_DESC_ADHKAR, META_TITLE_ADHKAR, TITLE_CONSTANTS } from '$lib/constants';
 	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
 	import SpeakerWaveIcon from '$lib/icons/SpeakerWaveIcon.svelte';
 	import SpeakerXMarkIcon from '$lib/icons/SpeakerXMarkIcon.svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import { onMount } from 'svelte';
 	import { getAdhkarFor, type AdhkarPeriod } from '../../data/adhkar';
 	import { formatDate } from '$lib/utils/date';
@@ -29,18 +32,34 @@
 	let manualOverride = $state(false);
 	let log: AdhkarLog = $state({});
 	let soundOn = $state(true);
+	let playMode = $state(true);
+	let currentPlayIndex = $state(0);
+	let slideDir = $state(1);
 
 	const todayKey = $derived(formatDate(new Date().toISOString(), 'YYYYMMDD'));
 	const items = $derived(getAdhkarFor(period));
+	const total = $derived(items.length);
 	const completed = $derived(
 		items.filter((i) => getCount(log, todayKey, period, i.id) >= i.count).length
 	);
-	const total = $derived(items.length);
 	const allDone = $derived(total > 0 && completed === total);
+	const currentItem = $derived(currentPlayIndex < total ? items[currentPlayIndex] : null);
 
-	function selectPeriod(next: AdhkarPeriod) {
-		period = next;
+	const periodOptions = $derived([
+		{ value: 'morning', label: isEnglish ? '🌅 Morning' : '🌅 Pagi' },
+		{ value: 'evening', label: isEnglish ? '🌙 Evening' : '🌙 Petang' }
+	]);
+
+	const modeOptions = $derived([
+		{ value: 'play', label: isEnglish ? '🎯 One by One' : '🎯 Satu per Satu' },
+		{ value: 'all', label: isEnglish ? '📋 See All' : '📋 Lihat Semua' }
+	]);
+
+	function selectPeriod(next: string) {
+		period = next as AdhkarPeriod;
 		manualOverride = true;
+		currentPlayIndex = 0;
+		slideDir = 1;
 	}
 
 	function handleIncrement(id: string, target: number) {
@@ -53,6 +72,22 @@
 
 	function handleResetAll() {
 		log = resetCount(log, todayKey, period);
+		currentPlayIndex = 0;
+		slideDir = 1;
+	}
+
+	function goNext() {
+		if (currentPlayIndex < total - 1) {
+			slideDir = 1;
+			currentPlayIndex++;
+		}
+	}
+
+	function goPrev() {
+		if (currentPlayIndex > 0) {
+			slideDir = -1;
+			currentPlayIndex--;
+		}
 	}
 
 	onMount(() => {
@@ -66,6 +101,12 @@
 		if (detected && !manualOverride) {
 			period = detected;
 		}
+		// Jump to first incomplete card
+		const periodItems = getAdhkarFor(period);
+		const firstIncomplete = periodItems.findIndex(
+			(item) => getCount(log, todayKey, period, item.id) < item.count
+		);
+		currentPlayIndex = firstIncomplete >= 0 ? firstIncomplete : 0;
 	});
 </script>
 
@@ -96,38 +137,18 @@
 	/>
 </div>
 
-<div class="px-4 flex flex-col gap-4 pb-8">
-	<div class="grid grid-cols-2 gap-2 bg-secondary p-1 rounded-xl">
-		<button
-			type="button"
-			onclick={() => selectPeriod('morning')}
-			class="rounded-lg px-3 py-2 text-sm font-semibold transition cursor-pointer {period ===
-			'morning'
-				? 'bg-primary shadow border border-foreground/20'
-				: 'opacity-70 hover:opacity-100'}"
-			aria-pressed={period === 'morning'}
-		>
-			🌅 {isEnglish ? 'Morning' : 'Pagi'}
-		</button>
-		<button
-			type="button"
-			onclick={() => selectPeriod('evening')}
-			class="rounded-lg px-3 py-2 text-sm font-semibold transition cursor-pointer {period ===
-			'evening'
-				? 'bg-primary shadow border border-foreground/20'
-				: 'opacity-70 hover:opacity-100'}"
-			aria-pressed={period === 'evening'}
-		>
-			🌙 {isEnglish ? 'Evening' : 'Petang'}
-		</button>
-	</div>
+<div class="px-4 flex flex-col gap-4 pb-24">
+	<!-- Period selector tabs -->
+	<Tabs options={periodOptions} value={period} onchange={selectPeriod} />
 
+	<!-- Banner -->
 	{#if period === 'morning'}
 		<MorningBanner />
 	{:else}
 		<EveningBanner />
 	{/if}
 
+	<!-- Progress card -->
 	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
 		<div class="flex items-center justify-between gap-3">
 			<div>
@@ -145,37 +166,17 @@
 					{/if}
 				</p>
 			</div>
-			<div class="flex items-center gap-2">
-				<button
-					type="button"
-					onclick={() => (soundOn = !soundOn)}
-					aria-label={soundOn
-						? isEnglish
-							? 'Mute'
-							: 'Matikan suara'
-						: isEnglish
-							? 'Unmute'
-							: 'Hidupkan suara'}
-					class="cursor-pointer rounded-lg p-2 bg-primary border-2 border-foreground/20 hover:border-foreground/40"
-				>
-					{#if soundOn}
-						<SpeakerWaveIcon size="sm" />
-					{:else}
-						<SpeakerXMarkIcon size="sm" />
-					{/if}
-				</button>
-				<button
-					type="button"
-					onclick={handleResetAll}
-					class="cursor-pointer rounded-lg px-3 py-2 text-xs font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40"
-				>
-					{isEnglish ? 'Reset all' : 'Reset semua'}
-				</button>
-			</div>
+			<button
+				type="button"
+				onclick={handleResetAll}
+				class="cursor-pointer rounded-lg px-3 py-2 text-xs font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 transition"
+			>
+				{isEnglish ? 'Reset all' : 'Reset semua'}
+			</button>
 		</div>
 		<div class="w-full bg-primary rounded-full h-2 overflow-hidden">
 			<div
-				class="h-2 rounded-full transition-all duration-300 {allDone
+				class="h-2 rounded-full transition-all duration-500 {allDone
 					? 'bg-green-500'
 					: 'bg-blue-500'}"
 				style="width: {total === 0 ? 0 : (completed / total) * 100}%"
@@ -183,17 +184,300 @@
 		</div>
 	</div>
 
-	<div class="flex flex-col gap-3">
-		{#each items as item (item.id)}
-			<AdhkarCounter
-				{item}
-				{soundOn}
-				count={getCount(log, todayKey, period, item.id)}
-				onIncrement={() => handleIncrement(item.id, item.count)}
-				onReset={() => handleReset(item.id)}
-			/>
-		{/each}
-	</div>
+	<!-- Mode selector (hidden during celebration) -->
+	{#if !allDone}
+		<Tabs
+			options={modeOptions}
+			value={playMode ? 'play' : 'all'}
+			onchange={(v) => {
+				playMode = v === 'play';
+			}}
+		/>
+	{/if}
+
+	<!-- ===== CELEBRATION SCREEN ===== -->
+	{#if allDone}
+		<div
+			class="celebration flex flex-col items-center gap-6 py-6 text-center"
+			in:fly={{ y: 60, duration: 500, easing: cubicOut }}
+		>
+			<!-- Trophy with sparkles -->
+			<div class="relative w-32 h-32 flex items-center justify-center">
+				<span class="trophy text-7xl select-none">🏆</span>
+				<span class="sparkle s1 absolute text-2xl select-none">✨</span>
+				<span class="sparkle s2 absolute text-xl select-none">⭐</span>
+				<span class="sparkle s3 absolute text-2xl select-none">✨</span>
+				<span class="sparkle s4 absolute text-lg select-none">⭐</span>
+			</div>
+
+			<!-- Headline -->
+			<div class="flex flex-col gap-2">
+				<h2 class="text-3xl font-bold">MashAllah! 🎉</h2>
+				<p class="text-xl font-semibold">
+					{isEnglish ? 'All Adhkar Complete!' : 'Semua Dzikir Selesai!'}
+				</p>
+				<p class="text-sm opacity-70 max-w-xs mx-auto">
+					{isEnglish
+						? `You completed all ${total} ${period === 'morning' ? 'morning' : 'evening'} adhkar today`
+						: `Kamu telah menyelesaikan semua ${total} dzikir ${period === 'morning' ? 'pagi' : 'petang'} hari ini`}
+				</p>
+			</div>
+
+			<!-- Stats -->
+			<div
+				class="bg-green-50 dark:bg-green-950/60 border-2 border-green-200 dark:border-green-800 rounded-2xl px-10 py-5 flex flex-col items-center"
+			>
+				<span class="text-5xl font-bold text-green-600 dark:text-green-400 tabular-nums"
+					>{total}</span
+				>
+				<span class="text-sm text-green-700 dark:text-green-300 mt-1">
+					{isEnglish ? 'Adhkar completed' : 'Dzikir selesai'}
+				</span>
+			</div>
+
+			<!-- Motivational quote -->
+			<div class="bg-secondary rounded-xl p-4 text-sm opacity-80 italic max-w-sm text-center">
+				"...{isEnglish
+					? 'Remember Allah much so that you may succeed'
+					: 'Dan ingatlah Allah sebanyak-banyaknya agar kamu beruntung'}." (QS. 8:45)
+			</div>
+
+			<!-- Action buttons -->
+			<div class="flex flex-col gap-3 w-full">
+				<button
+					type="button"
+					onclick={handleResetAll}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition"
+				>
+					{isEnglish ? '↺ Start again' : '↺ Mulai lagi'}
+				</button>
+				<button
+					type="button"
+					onclick={() => selectPeriod(period === 'morning' ? 'evening' : 'morning')}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition text-sm"
+				>
+					{period === 'morning'
+						? isEnglish
+							? '🌙 Switch to Evening Adhkar'
+							: '🌙 Lanjut ke Dzikir Petang'
+						: isEnglish
+							? '🌅 Switch to Morning Adhkar'
+							: '🌅 Lanjut ke Dzikir Pagi'}
+				</button>
+				<button
+					type="button"
+					onclick={() => {
+						playMode = false;
+					}}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition text-sm opacity-70"
+				>
+					{isEnglish ? '📋 See all cards' : '📋 Lihat semua dzikir'}
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== PLAY MODE ===== -->
+	{:else if playMode}
+		<div class="flex flex-col gap-4">
+			<!-- Step indicator -->
+			<div class="flex flex-col items-center gap-2">
+				<p class="text-sm font-semibold opacity-70">
+					{isEnglish
+						? `Dhikr ${currentPlayIndex + 1} of ${total}`
+						: `Dzikir ke-${currentPlayIndex + 1} dari ${total}`}
+				</p>
+				<div class="flex gap-2 items-center justify-center flex-wrap">
+					{#each items as item, i}
+						{@const isDone = getCount(log, todayKey, period, item.id) >= item.count}
+						<div
+							class="rounded-full transition-all duration-300 {isDone
+								? 'w-2.5 h-2.5 bg-green-500 dark:bg-green-400'
+								: i === currentPlayIndex
+									? 'w-3.5 h-3.5 bg-blue-500 dark:bg-blue-400 ring-2 ring-blue-300/60 dark:ring-blue-600/60'
+									: 'w-2.5 h-2.5 bg-foreground/15'}"
+						></div>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Card stack with ghost cards -->
+			<div class="relative" style="padding-bottom: 20px;">
+				<!-- Ghost card 2 (furthest back) -->
+				{#if currentPlayIndex + 2 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/10"
+						style="bottom: 0; left: 24px; right: 24px; height: 28px; z-index: 1;"
+					></div>
+				{/if}
+				<!-- Ghost card 1 (one behind) -->
+				{#if currentPlayIndex + 1 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/15 shadow-sm"
+						style="bottom: 8px; left: 12px; right: 12px; height: 28px; z-index: 2;"
+					></div>
+				{/if}
+
+				<!-- Animated current card -->
+				<div class="relative overflow-x-hidden" style="z-index: 3;">
+					{#key currentPlayIndex}
+						<div
+							in:fly={{ x: slideDir * 380, duration: 380, easing: cubicOut }}
+							out:fly={{ x: -slideDir * 380, duration: 280 }}
+						>
+							{#if currentItem}
+								<AdhkarCounter
+									item={currentItem}
+									count={getCount(log, todayKey, period, currentItem.id)}
+									{soundOn}
+									playMode={true}
+									isLast={currentPlayIndex === total - 1}
+									onIncrement={() => handleIncrement(currentItem.id, currentItem.count)}
+									onReset={() => handleReset(currentItem.id)}
+									onNext={goNext}
+								/>
+							{/if}
+						</div>
+					{/key}
+				</div>
+			</div>
+
+			<!-- Prev / Next navigation -->
+			<div class="flex items-center justify-between">
+				<button
+					type="button"
+					onclick={goPrev}
+					disabled={currentPlayIndex === 0}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					← {isEnglish ? 'Previous' : 'Sebelumnya'}
+				</button>
+				<button
+					type="button"
+					onclick={goNext}
+					disabled={currentPlayIndex >= total - 1 ||
+						!(getCount(log, todayKey, period, currentItem?.id ?? '') >= (currentItem?.count ?? 0))}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					{isEnglish ? 'Next' : 'Berikutnya'} →
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== ALL MODE ===== -->
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each items as item (item.id)}
+				<AdhkarCounter
+					{item}
+					{soundOn}
+					count={getCount(log, todayKey, period, item.id)}
+					onIncrement={() => handleIncrement(item.id, item.count)}
+					onReset={() => handleReset(item.id)}
+				/>
+			{/each}
+		</div>
+	{/if}
 </div>
 
+<!-- Floating mute button -->
+<button
+	type="button"
+	onclick={() => (soundOn = !soundOn)}
+	aria-label={soundOn
+		? isEnglish
+			? 'Mute sound'
+			: 'Matikan suara'
+		: isEnglish
+			? 'Unmute sound'
+			: 'Hidupkan suara'}
+	class="fixed bottom-6 right-4 z-40 rounded-full w-12 h-12 bg-primary border-2 border-foreground/20 shadow-lg hover:border-foreground/40 cursor-pointer flex items-center justify-center transition-all active:scale-90 {soundOn
+		? ''
+		: 'opacity-60'}"
+>
+	{#if soundOn}
+		<SpeakerWaveIcon size="sm" />
+	{:else}
+		<SpeakerXMarkIcon size="sm" />
+	{/if}
+</button>
+
 <SeoText variant="ADHKAR" />
+
+<style>
+	@keyframes trophy-pop {
+		0% {
+			transform: scale(0.3) rotate(-10deg);
+			opacity: 0;
+		}
+		55% {
+			transform: scale(1.2) rotate(5deg);
+		}
+		75% {
+			transform: scale(0.92) rotate(-3deg);
+		}
+		90% {
+			transform: scale(1.04) rotate(1deg);
+		}
+		100% {
+			transform: scale(1) rotate(0deg);
+			opacity: 1;
+		}
+	}
+
+	@keyframes float {
+		0%,
+		100% {
+			transform: translateY(0px);
+		}
+		50% {
+			transform: translateY(-10px);
+		}
+	}
+
+	@keyframes sparkle {
+		0%,
+		100% {
+			opacity: 0;
+			transform: scale(0) rotate(0deg);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1.2) rotate(180deg);
+		}
+	}
+
+	.trophy {
+		animation:
+			trophy-pop 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) both,
+			float 3s ease-in-out 0.8s infinite;
+		display: inline-block;
+	}
+
+	.sparkle {
+		animation: sparkle 2s ease-in-out infinite;
+	}
+
+	.s1 {
+		top: 0;
+		right: 4px;
+		animation-delay: 0s;
+	}
+
+	.s2 {
+		bottom: 4px;
+		left: 0;
+		animation-delay: 0.5s;
+	}
+
+	.s3 {
+		top: 8px;
+		left: 0;
+		animation-delay: 1s;
+	}
+
+	.s4 {
+		bottom: 0;
+		right: 8px;
+		animation-delay: 1.5s;
+	}
+</style>

--- a/src/routes/asmaul-husna/+page.svelte
+++ b/src/routes/asmaul-husna/+page.svelte
@@ -444,14 +444,14 @@
 			⌨️ Space to play/pause · ← → to navigate
 		</p>
 
-		<!-- Name picker: scroll row -->
-		<div class="w-full max-w-sm">
+		<!-- Name picker: grid row -->
+		<div class="w-full">
 			<p class="text-xs text-foreground-secondary mb-2 font-medium">All names:</p>
-			<div class="flex gap-1.5 flex-wrap">
+			<div class="grid grid-cols-10 gap-1.5">
 				{#each asmaulHusna as _item, i}
 					<button
 						onclick={() => openInPlayable(i)}
-						class={`px-2 py-1 rounded-lg text-xs font-medium transition-all ${
+						class={`w-full py-1.5 rounded-lg text-xs font-medium text-center transition-all ${
 							currentIndex === i
 								? `bg-gradient-to-r ${getGradient(i)} text-white shadow-sm scale-105`
 								: 'bg-secondary text-foreground-secondary hover:text-foreground hover:bg-primary'

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -2,6 +2,7 @@
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import CardShadow from '$lib/CardShadow.svelte';
+	import Tabs from '$lib/ui/Tabs.svelte';
 	import Button from '$lib/ui/Button.svelte';
 	import IconButton from '$lib/ui/IconButton.svelte';
 	import Badge from '$lib/ui/Badge.svelte';
@@ -46,6 +47,8 @@
 	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
 
 	let showSheet = $state(false);
+	let demoTab2 = $state('morning');
+	let demoTab3 = $state('option-b');
 	let activeChip = $state<'all' | 'makkiyah' | 'madaniyah'>('all');
 	let bannerDismissed = $state(false);
 	let demoText = $state('');
@@ -105,6 +108,7 @@
 		{ id: 'buttons', label: $t('designSystem.section.buttons') },
 		{ id: 'icon-buttons', label: $t('designSystem.section.iconButtons') },
 		{ id: 'badges', label: $t('designSystem.section.badges') },
+		{ id: 'tabs', label: isEnglish ? 'Tabs' : 'Tab' },
 		{ id: 'chips', label: $t('designSystem.section.chips') },
 		{ id: 'banners', label: $t('designSystem.section.banners') },
 		{ id: 'forms', label: $t('designSystem.section.forms') },
@@ -646,6 +650,49 @@
 
 			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
 					>{'<Badge variant="solid | subtle | outline"\n       color="primary | secondary | info | success | warning | danger"\n       size="sm | md | lg">label</Badge>'}</code
+				></pre>
+		</CardShadow>
+	</section>
+
+	<!-- TABS -->
+	<section id="tabs" class="flex flex-col gap-3 scroll-mt-4">
+		<h2 class="text-xl font-bold">{isEnglish ? 'Tabs' : 'Tab'}</h2>
+		<p class="text-sm opacity-75">
+			{isEnglish
+				? 'Sliding-indicator tab component. Best for balanced selectors with 2–4 options. The pill indicator animates smoothly when switching tabs.'
+				: 'Komponen tab dengan indikator geser. Cocok untuk selektor seimbang dengan 2–4 pilihan. Indikator bergerak mulus saat berganti tab.'}
+		</p>
+
+		<CardShadow class="flex flex-col gap-5">
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold text-sm">{isEnglish ? '2 options' : '2 pilihan'}</h3>
+				<Tabs
+					options={[
+						{ value: 'morning', label: '🌅 Pagi' },
+						{ value: 'evening', label: '🌙 Petang' }
+					]}
+					value={demoTab2}
+					onchange={(v) => (demoTab2 = v)}
+				/>
+				<p class="text-xs opacity-60">{isEnglish ? 'Selected:' : 'Dipilih:'} {demoTab2}</p>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h3 class="font-semibold text-sm">{isEnglish ? '3 options' : '3 pilihan'}</h3>
+				<Tabs
+					options={[
+						{ value: 'option-a', label: '🎯 Satu per Satu' },
+						{ value: 'option-b', label: '📋 Semua' },
+						{ value: 'option-c', label: '⚙️ Setelan' }
+					]}
+					value={demoTab3}
+					onchange={(v) => (demoTab3 = v)}
+				/>
+				<p class="text-xs opacity-60">{isEnglish ? 'Selected:' : 'Dipilih:'} {demoTab3}</p>
+			</div>
+
+			<pre class="text-xs bg-primary p-2 rounded overflow-auto"><code
+					>{"<Tabs\n  options={[{ value: 'a', label: 'Option A' }, { value: 'b', label: 'Option B' }]}\n  value={selected}\n  onchange={(v) => (selected = v)}\n/>"}</code
 				></pre>
 		</CardShadow>
 	</section>

--- a/src/routes/jadwal-sholat/+page.svelte
+++ b/src/routes/jadwal-sholat/+page.svelte
@@ -21,6 +21,7 @@
 	import { formatHijriDate } from '$lib/utils/hijri';
 	import { languageStore } from '$lib/checkLanguaguage';
 	import { todayPrayerTimings, nextPrayerInfo } from '../../store/prayerReminder';
+	import PrayerTimeIllustration from '$lib/illustrations/PrayerTimeIllustration.svelte';
 
 	const BASE_URL = 'https://api.aladhan.com/v1/calendar';
 
@@ -239,25 +240,25 @@
 		</Button>
 	</div>
 
+	<!-- Time-based illustration -->
+	<PrayerTimeIllustration {hours} />
+
 	<!-- Clock + Hijri -->
-	<div class="px-4 py-4 flex items-center justify-between gap-4">
-		<div class="flex-1 min-w-0">
-			<div class="text-4xl font-bold font-mono tabular-nums leading-none">
-				{String(hours).padStart(2, '0')}:{String(minutes).padStart(2, '0')}<span
-					class="text-2xl opacity-40">:{String(seconds).padStart(2, '0')}</span
-				>
-			</div>
-			<div class="text-sm opacity-60 mt-2">
-				{now.toLocaleDateString($languageStore === 'id' ? 'id-ID' : 'en-US', {
-					weekday: 'long',
-					day: 'numeric',
-					month: 'long',
-					year: 'numeric'
-				})}
-			</div>
-			<div class="text-xs opacity-40 mt-0.5">{hijriToday}</div>
+	<div class="px-4 py-4">
+		<div class="text-4xl font-bold font-mono tabular-nums leading-none">
+			{String(hours).padStart(2, '0')}:{String(minutes).padStart(2, '0')}<span
+				class="text-2xl opacity-40">:{String(seconds).padStart(2, '0')}</span
+			>
 		</div>
-		<div class="text-5xl opacity-15 select-none shrink-0" aria-hidden="true">🕌</div>
+		<div class="text-sm opacity-60 mt-2">
+			{now.toLocaleDateString($languageStore === 'id' ? 'id-ID' : 'en-US', {
+				weekday: 'long',
+				day: 'numeric',
+				month: 'long',
+				year: 'numeric'
+			})}
+		</div>
+		<div class="text-xs opacity-40 mt-0.5">{hijriToday}</div>
 	</div>
 </div>
 

--- a/src/routes/pencatat-ibadah/+page.svelte
+++ b/src/routes/pencatat-ibadah/+page.svelte
@@ -15,6 +15,7 @@
 	import Button from '$lib/ui/Button.svelte';
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import { t } from '$lib/translations/store';
+	import CheckCircleSolidIcon from '$lib/icons/CheckCircleSolidIcon.svelte';
 
 	const FARD_PRAYERS: Array<{
 		key: PrayerKey;
@@ -314,7 +315,10 @@
 					<span class="text-3xl">{prayer.emoji}</span>
 					<span class="font-semibold text-sm">{prayer.title}</span>
 					{#if done}
-						<span class="text-xs text-green-600 dark:text-green-400 font-medium">✓ Selesai</span>
+						<span
+							class="flex items-center gap-1 text-xs text-green-600 dark:text-green-400 font-medium"
+							><CheckCircleSolidIcon size="sm" />Selesai</span
+						>
 					{:else}
 						<span class="text-xs opacity-30">Belum</span>
 					{/if}
@@ -345,7 +349,10 @@
 					<span class="text-3xl">{prayer.emoji}</span>
 					<span class="font-semibold text-sm text-center leading-tight">{prayer.title}</span>
 					{#if done}
-						<span class="text-xs text-amber-600 dark:text-amber-400 font-medium">✓ Selesai</span>
+						<span
+							class="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 font-medium"
+							><CheckCircleSolidIcon size="sm" />Selesai</span
+						>
 					{:else}
 						<span class="text-xs opacity-30">Belum</span>
 					{/if}


### PR DESCRIPTION
- Add Tabs.svelte to design system: sliding pill indicator transitions smoothly
  between 2–4 options; replaces the manual morning/evening toggle
- Rewrite adhkar page with play mode (default) showing one card at a time:
  prominent step counter (dots + "Dzikir ke-N dari M"), card stack ghost cards
  peeking from behind to signal remaining cards, fly animation when advancing
- AdhkarCounter gains playMode prop: large circle order badge, bigger Arabic
  text, full-width "Tap (+1) (N more)" button, "Next Dhikr →" when done
- Celebration/reward screen on completion: trophy pop+float animation, sparkle
  stars, stats card, motivational quote, "Start again" and "Switch period" CTAs
- "See All" mode toggle preserved as secondary option via Tabs component
- Mute button moved to fixed floating pill (bottom-right) visible at all scrolls
- Design system page: Tabs section with 2-option and 3-option demos + code snippet

https://claude.ai/code/session_015V4sYcRTbbhfj7S74nG1Bc