### PR TITLE
feat(wirid/tahlil): full redesign with play mode, progress tracking, and complete Arabic text

### DIFF
--- a/src/data/tahlil.ts
+++ b/src/data/tahlil.ts
@@ -1,107 +1,222 @@
 export type TahlilItem = {
 	id: number;
+	order: number;
 	title: string;
 	arabic: string;
+	latin: string;
 	translation: string;
+	translationEn: string;
+	count: number;
+	note?: string;
+	noteEn?: string;
+	href?: string;
 };
 
 const source =
-	'https://islam.nu.or.id/post/read/107344/susunan-bacaan-tahlil-doa-arwah-lengkap-dan-terjemahannya';
-const basedOn = "Majmu' Syarif";
+	'https://islam.nu.or.id/tahlil/susunan-bacaan-tahlil-doa-arwah-lengkap-dan-terjemahannya';
+const basedOn = 'Majmu’ Syarif (NU)';
+
 const tahlilData: TahlilItem[] = [
 	{
-		id: 2,
-		title: 'Al-Fatihah',
+		id: 1,
+		order: 1,
+		title: 'Al-Fatihah — Tawassul',
 		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ . اَلْحَمْدُ لِلهِ رَبِّ الْعَالَمِيْنَ . اَلرَّحْمَنِ الرَّحِيْمِ. مَالِكِ يَوْمِ الدِّيْنِ . اِيَّاكَ نَعْبُدُ وَاِيَّاكَ نَسْتَعِيْنُ . اِهْدِنَا الصِّرَاطَ الَّمُسْتَقِيْمَ . صِرَاطَ الَّذِ يْنَ اَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوْبِ عَلَيْهِمْ وَلَا الضَّالِّيْنَ . اَمِينْ',
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ. الرَّحْمَٰنِ الرَّحِيمِ. مَالِكِ يَوْمِ الدِّينِ. إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ. اهْدِنَا الصِّرَاطَ الْمُسْتَقِيمَ. صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلَا الضَّالِّينَ. آمِينْ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Alhamdu lillaahi rabbil-’aalamiin. Ar-rahmaanir-rahiim. Maaliki yawmid-diin. Iyyaaka na’budu wa iyyaaka nasta’iin. Ihdinash-shiraathal-mustaqiim. Shiraathal-ladziina an’amta ’alayhim, ghayril-maghdhuubi ’alayhim wa ladhdhaalliin. Aamiin',
 		translation:
-			'Aku berlindung kepada Allah dari setan yang terlontar. Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Segala puji bagi Allah, Tuhan semesta alam. Yang maha pengasih lagi maha penyayang. Yang menguasai hari pembalasan. Hanya kepada-Mu kami menyembah. Hanya kepada-Mu pula kami memohon pertolongan. Tunjukkanlah kami ke jalan yang lurus, yaitu jalan orang-orang yang telah Kauanugerahi nikmat kepada mereka, bukan jalan mereka yang dimurkai dan bukan pula jalan mereka yang sesat. Semoga Kau kabulkan permohonan kami'
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Segala puji bagi Allah, Tuhan semesta alam. Yang Maha Pengasih lagi Maha Penyayang. Yang menguasai hari pembalasan. Hanya kepada-Mu kami menyembah, dan hanya kepada-Mu kami memohon pertolongan. Tunjukkanlah kami ke jalan yang lurus. Yaitu jalan orang-orang yang Engkau beri nikmat; bukan jalan mereka yang dimurkai dan bukan pula jalan mereka yang sesat. Amin.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. All praise is due to Allah, Lord of the worlds. The Most Gracious, the Most Merciful. Sovereign of the Day of Recompense. It is You we worship and You we ask for help. Guide us to the straight path — the path of those upon whom You have bestowed favor, not of those who have earned anger or of those who are astray. Amen.',
+		count: 1,
+		note: 'Pahalanya dihadiahkan kepada Nabi Muhammad SAW, keluarga, sahabat, dan arwah yang didoakan',
+		noteEn:
+			'Its reward is dedicated to the Prophet, his family, companions, and the souls being remembered'
+	},
+	{
+		id: 2,
+		order: 2,
+		title: 'Surat Al-Ikhlas',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ هُوَ اللَّهُ أَحَدٌ. اللَّهُ الصَّمَدُ. لَمْ يَلِدْ وَلَمْ يُولَدْ. وَلَمْ يَكُن لَّهُ كُفُوًا أَحَدٌ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul huwallaahu ahad. Allaahus-shamad. Lam yalid wa lam yuulad. Wa lam yakul lahuu kufuwan ahad',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Dialah Allah, Yang Maha Esa. Allah adalah Tuhan yang bergantung kepada-Nya segala sesuatu. Dia tiada beranak dan tiada pula diperanakkan. Dan tidak ada seorang pun yang setara dengan Dia.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: He is Allah, the One. Allah, the Eternal Refuge. He neither begets nor is born. Nor is there to Him any equivalent.',
+		count: 3
 	},
 	{
 		id: 3,
-		title: 'Surat Al-Ikhlas (3 kali)',
-		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ . قُلْ هُوَ اللهُ اَحَدٌ . اَللهُ الصَّمَدُ . لَمْ يَلِدْ وَلَمْ يُوْلَدْ . وَلَمْ يَكٌنْ لَهُ كُفُوًا اَحَدٌ',
-		translation:
-			'Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Katakanlah, ‘Dialah yang maha esa. Allah adalah tuhan tempat bergantung oleh segala sesuatu. Dia tidak beranak dan tidak diperanakkan. Dan tidak ada seorangpun yang setara dengan-Nya’. (3 kali)'
+		order: 3,
+		title: 'Tahlil — La ilaha illallah',
+		arabic: 'لَا إِلَهَ إِلَّا اللَّهُ',
+		latin: 'Laa ilaaha illallaah',
+		translation: 'Tiada Tuhan selain Allah',
+		translationEn: 'There is no deity except Allah',
+		count: 3
 	},
 	{
 		id: 4,
-		title: 'Tahlil dan Takbir',
-		arabic: 'لاَ اِلَهَ اِلاَّ اللهُ وَاللهُ اَكْبَرُ',
-		translation: 'Tiada tuhan yang layak disembah kecuali Allah. Allah maha besar'
+		order: 4,
+		title: 'Surat Al-Falaq',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ أَعُوذُ بِرَبِّ الْفَلَقِ. مِنْ شَرِّ مَا خَلَقَ. وَمِنْ شَرِّ غَاسِقٍ إِذَا وَقَبَ. وَمِنْ شَرِّ النَّفَّاثَاتِ فِي الْعُقَدِ. وَمِنْ شَرِّ حَاسِدٍ إِذَا حَسَدَ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul a’uudzu bi rabbil-falaq. Min syarri maa khalaq. Wa min syarri ghaasiqin idzaa waqab. Wa min syarrin-naffaatsaati fil-’uqad. Wa min syarri haasidin idzaa hasad',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Aku berlindung kepada Tuhan yang menguasai subuh. Dari kejahatan makhluk-Nya. Dan dari kejahatan malam apabila telah gelap gulita. Dan dari kejahatan wanita-wanita tukang sihir yang menghembus pada buhul-buhul. Dan dari kejahatan pendengki bila ia dengki.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: I seek refuge in the Lord of daybreak. From the evil of that which He created. And from the evil of darkness when it settles. And from the evil of the blowers in knots. And from the evil of an envier when he envies.',
+		count: 1
 	},
 	{
 		id: 5,
-		title: 'Surat Al-Falaq',
+		order: 5,
+		title: 'Surat An-Nas',
 		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ. قُلْ اَعُوْذُ بِرَبِّ الْفَلَقِ. مِنْ شَرِّ مَا خَلَقَ. وَمِنْ شَرِّ غَاسِقٍ اِذَا وَقَبَ. وَمِنْ شَرِّ النَّفَاثاتِ فِى الْعُقَدِ. وَمِنْ شَرِّ حَاسِدٍ اِذَا حَسَدَ',
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ أَعُوذُ بِرَبِّ النَّاسِ. مَلِكِ النَّاسِ. إِلَهِ النَّاسِ. مِنْ شَرِّ الْوَسْوَاسِ الْخَنَّاسِ. الَّذِي يُوَسْوِسُ فِي صُدُورِ النَّاسِ. مِنَ الْجِنَّةِ وَالنَّاسِ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul a’uudzu bi rabbin-naas. Malikin-naas. Ilaahin-naas. Min syarril-waswaasil-khannaas. Alladzii yuwaswisu fii shuduurin-naas. Minal-jinnati wan-naas',
 		translation:
-			'Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Katakanlah, ‘Aku berlindung kepada tuhan yang menguasai waktu subuh dari kejahatan makhluk-Nya. Dari kejahatan malam apabila telah gelap gulita. Dan dari kejahatan wanita-wanita tukang sihir yang mengembus nafasnya pada buhul-buhul. Dan dari kejahatan orang-orang yang dengki apabila ia mendengki.’'
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Aku berlindung kepada Tuhan manusia. Raja manusia. Sembahan manusia. Dari kejahatan bisikan setan yang biasa bersembunyi. Yang membisikkan kejahatan ke dalam dada manusia. Dari golongan jin dan manusia.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: I seek refuge in the Lord of mankind. The Sovereign of mankind. The God of mankind. From the evil of the retreating whisperer. Who whispers in the breasts of mankind. From among the jinn and mankind.',
+		count: 1
 	},
 	{
 		id: 6,
-		title: 'Tahlil dan Takbir',
-		arabic: 'لاَ اِلَهَ اِلاَّ اللهُ وَاللهُ اَكْبَرُ',
-		translation: 'Tiada tuhan yang layak disembah kecuali Allah. Allah maha besar'
+		order: 6,
+		title: 'Al-Fatihah — Penutup Pembukaan',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ. الرَّحْمَٰنِ الرَّحِيمِ. مَالِكِ يَوْمِ الدِّينِ. إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ. اهْدِنَا الصِّرَاطَ الْمُسْتَقِيمَ. صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلَا الضَّالِّينَ. آمِينْ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Alhamdu lillaahi rabbil-’aalamiin. Ar-rahmaanir-rahiim. Maaliki yawmid-diin. Iyyaaka na’budu wa iyyaaka nasta’iin. Ihdinash-shiraathal-mustaqiim. Shiraathal-ladziina an’amta ’alayhim, ghayril-maghdhuubi ’alayhim wa ladhdhaalliin. Aamiin',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Segala puji bagi Allah, Tuhan semesta alam. Yang Maha Pengasih lagi Maha Penyayang. Yang menguasai hari pembalasan. Hanya kepada-Mu kami menyembah, dan hanya kepada-Mu kami memohon pertolongan. Tunjukkanlah kami ke jalan yang lurus. Yaitu jalan orang-orang yang Engkau beri nikmat; bukan jalan mereka yang dimurkai dan bukan pula jalan mereka yang sesat. Amin.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. All praise is due to Allah, Lord of the worlds. The Most Gracious, the Most Merciful. Sovereign of the Day of Recompense. It is You we worship and You we ask for help. Guide us to the straight path — the path of those upon whom You have bestowed favor, not of those who have earned anger or of those who are astray. Amen.',
+		count: 1
 	},
 	{
 		id: 7,
-		title: 'Surat An-Nas',
+		order: 7,
+		title: 'Awal Al-Baqarah (1–5)',
 		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ. قُلْ اَعُوذُ بِرَبِّ النَّاسِ. مَلِكِ النَّاسِ. اِلَهِ النَّاسِ. مِنْ شَرِّ الْوَسْوَاسِ الْخَنَّاسِ. الَّذِى يُوَسْوِسُ فِى صُدُوْرِ النَّاسِ. مِنَ الْجِنَّةِ وَالنَّاسِ',
+			'الم. ذَالِكَ الْكِتَابُ لَا رَيْبَ فِيهِ هُدًى لِّلْمُتَّقِينَ. الَّذِينَ يُؤْمِنُونَ بِالْغَيْبِ وَيُقِيمُونَ الصَّلَوٰةَ وَمِمَّا رَزَقْنَاهُمْ يُنْفِقُونَ. وَالَّذِينَ يُؤْمِنُونَ بِمَا أُنزِلَ إِلَيْكَ وَمَا أُنزِلَ مِنْ قَبْلِكَ وَبِالْآخِرَةِ هُمْ يُوقِنُونَ. أُوْلَـٰئِكَ عَلَىٰ هُدًى مِّن رَّبِّهِمْ وَأُوْلَـٰئِكَ هُمُ الْمُفْلِحُونَ',
+		latin:
+			'Alif laam miim. Dzaalikal-kitaabu laa rayba fiih, hudal lil-muttaqiin. Alladziina yu’minuuna bil-ghaybi wa yuqiimuunas-shalaata wa mimmaa razaqnaahum yunfiquun. Walladziina yu’minuuna bimaa unzila ilayka wa maa unzila min qablik, wa bil-aakhirati hum yuuqinuun. Ulaa’ika ’alaa hudam mir rabbihim wa ulaa’ika humul-muflihuun',
 		translation:
-			'Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Katakanlah, ‘Aku berlindung kepada tuhan manusia, raja manusia. Sesembahan manusia, dari kejahatan bisikan setan yang biasa bersembunyi. Yang membisikkan kejahatan ke dalam dada manusia. Dari setan dan manusia.’'
+			'Alif Lam Mim. Kitab ini tidak ada keraguan padanya; petunjuk bagi mereka yang bertakwa. Yaitu mereka yang beriman kepada yang gaib, yang mendirikan shalat, dan menafkahkan sebagian rezeki yang Kami anugerahkan kepada mereka. Dan mereka yang beriman kepada Kitab yang telah diturunkan kepadamu dan Kitab-kitab yang telah diturunkan sebelummu, serta mereka yakin akan adanya kehidupan akhirat. Mereka itulah yang tetap mendapat petunjuk dari Tuhan mereka, dan merekalah orang-orang yang beruntung.',
+		translationEn:
+			'Alif Lam Mim. This is the Book about which there is no doubt, a guidance for those conscious of Allah — who believe in the unseen, establish prayer, and spend out of what We have provided for them, and who believe in what has been revealed to you and what was revealed before you, and of the Hereafter they are certain. Those are upon guidance from their Lord, and it is those who are the successful.',
+		count: 1
 	},
 	{
 		id: 8,
-		title: 'Tahlil dan Takbir',
-		arabic: 'لاَ اِلَهَ اِلاَّ اللهُ وَاللهُ اَكْبَرُ',
-		translation: 'Tiada tuhan yang layak disembah kecuali Allah. Allah maha besar'
+		order: 8,
+		title: 'Al-Baqarah 163',
+		arabic: 'وَإِلَهُكُمْ إِلَهٌ وَاحِدٌ لَّا إِلَهَ إِلَّا هُوَ الرَّحْمَٰنُ الرَّحِيمُ',
+		latin: 'Wa ilaahukum ilaahuw waahid, laa ilaaha illaa huwar-rahmaanur-rahiim',
+		translation:
+			'Dan Tuhanmu adalah Tuhan Yang Maha Esa; tidak ada tuhan selain Dia, Yang Maha Pengasih lagi Maha Penyayang.',
+		translationEn:
+			'And your god is one God. There is no deity except Him, the Entirely Merciful, the Especially Merciful.',
+		count: 1
 	},
 	{
 		id: 9,
-		title: 'Al-Fatihah',
+		order: 9,
+		title: 'Ayat Kursi (Al-Baqarah 255)',
 		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ . اَلْحَمْدُ لِلهِ رَبِّ الْعَالَمِيْنَ . اَلرَّحْمَنِ الرَّحِيْمِ. مَالِكِ يَوْمِ الدِّيْنِ . اِيَّاكَ نَعْبُدُ وَاِيَّاكَ نَسْتَعِيْنُ . اِهْدِنَا الصِّرَاطَ الَّمُسْتَقِيْمَ . صِرَاطَ الَّذِ يْنَ اَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوْبِ عَلَيْهِمْ وَلَا الضَّالِّيْنَ . اَمِينْ',
+			'اللَّهُ لَا إِلَهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ لَا تَأْخُذُهُ سِنَةٌ وَلَا نَوْمٌ لَّهُ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ مَنْ ذَا الَّذِي يَشْفَعُ عِنْدَهُ إِلَّا بِإِذْنِهِ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ وَلَا يُحِيطُونَ بِشَيْءٍ مِّنْ عِلْمِهِ إِلَّا بِمَا شَاءَ وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَالْأَرْضَ وَلَا يَؤُودُهُ حِفْظُهُمَا وَهُوَ الْعَلِيُّ الْعَظِيمُ',
+		latin:
+			'Allaahu laa ilaaha illaa huwal-hayyul-qayyuum, laa ta’khudzuhu sinatuw wa laa naum, lahuu maa fis-samaawaati wa maa fil-ardh, man dzalladzii yasyfa’u ’indahu illaa bi-idznih, ya’lamu maa bayna aydiihim wa maa khalfahum, wa laa yuhiithuuna bisyay’im min ’ilmihii illaa bimaa syaa’, wasi’a kursiyyuhus-samaawaati wal-ardh, wa laa ya’uuduhuu hifzhuhumaa, wa huwal-’aliyyul-’azhiim',
 		translation:
-			'Aku berlindung kepada Allah dari setan yang terlontar. Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Segala puji bagi Allah, Tuhan semesta alam. Yang maha pengasih lagi maha penyayang. Yang menguasai hari pembalasan. Hanya kepada-Mu kami menyembah. Hanya kepada-Mu pula kami memohon pertolongan. Tunjukkanlah kami ke jalan yang lurus, yaitu jalan orang-orang yang telah Kauanugerahi nikmat kepada mereka, bukan jalan mereka yang dimurkai dan bukan pula jalan mereka yang sesat. Semoga Kau kabulkan permohonan kami'
+			'Allah, tidak ada tuhan selain Dia, Yang Maha Hidup lagi terus-menerus mengurus makhluk-Nya. Dia tidak dilanda oleh kantuk dan tidak pula oleh tidur. Milik-Nya apa yang ada di langit dan apa yang ada di bumi. Tidak ada yang dapat memberi syafaat di sisi-Nya tanpa izin-Nya. Dia mengetahui apa yang ada di hadapan mereka dan apa yang ada di belakang mereka, dan mereka tidak mengetahui sesuatu pun dari ilmu-Nya kecuali apa yang dikehendaki-Nya. Kursi-Nya meliputi langit dan bumi, dan Dia tidak merasa berat memelihara keduanya. Dialah Yang Maha Tinggi lagi Maha Agung.',
+		translationEn:
+			'Allah — there is no deity except Him, the Ever-Living, the Sustainer of existence. Neither drowsiness overtakes Him nor sleep. To Him belongs whatever is in the heavens and whatever is on the earth. Who is it that can intercede with Him except by His permission? He knows what is before them and what will be after them, and they encompass not a thing of His knowledge except for what He wills. His Kursi extends over the heavens and the earth, and their preservation tires Him not. And He is the Most High, the Most Great.',
+		count: 1
 	},
 	{
 		id: 10,
-		title: 'Awal Surat Al-Baqarah',
+		order: 10,
+		title: 'Al-Baqarah 284–286',
 		arabic:
-			'بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ. المّ. ذَلِكَ الكِتابُ لاَرَيْبَ فِيْهِ هُدَى لِلْمُتَّقِيْنَ. الَّذِيْنَ يُؤْمِنُونَ بِالْغَيْبِ وَيُقِيْمُونَ الصَّلَاةَ وَمِمَّا رَزَقْنَاهُمْ يُنْفِقُونَ. وَالَّذِيْنَ يُؤْمِنُونَ بِمَا اُنْزِلَ اِلَيْكَ وَمَا اُنْزِلَ مِن قَبْلِكَ وَبِالْاَخِرَةِ هُمْ يُوقِنُونَ. اُولَئِكَ عَلَى هُدًى مِّن رَّبِّهِمْ، وَاُولَئِكَ هُمُ الْمُفْلِحُونَ',
+			'لِلَّهِ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ وَإِن تُبْدُوا مَا فِي٠ أَنفُسِكُمْ أَوْ تُخْفُوهُ يُحَاسِبْكُم بِهِ اللَّهُ فَيَغْفِرُ لِمَن يَشَاءُ وَيُعَذِّبُ مَن يَشَاءُ وَاللَّهُ عَلَىٰ كُلِّ شَيْءٍ قَدِيرٌ. آمَنَ الرَّسُولُ بِمَا أُنزِلَ إِلَيْهِ مِن رَّبِّهِ وَالْمُؤْمِنُونَ كُلْ آمَنَ بِاللَّهِ وَمَلَائِكَتِهِ وَكُتُبِهِ وَرُسُلِهِ لَا نُفَرِّقُ بَيْنَ أَحَدٍ مِّن رُّسُلِهِ وَقَالُوا سَمِعْنَا وَأَطَعْنَا غُفْرَانَكَ رَبَّنَا وَإِلَيْكَ الْمَصِيرُ. لَا يُكَلِّفُ اللَّهُ نَفْسًا إِلَّا وُسْعَهَا لَهَا مَا كَسَبَتْ وَعَلَيْهَا مَا اكْتَسَبَتْ رَبَّنَا لَا تُؤَاخِذْنَا إِن نَّسِينَا أَوْ أَخْطَأْنَا رَبَّنَا وَلَا تَحْمِلْ عَلَيْنَا إِصْرًا كَمَا حَمَلْتَهُ عَلَى الَّذِينَ مِن قَبْلِنَا رَبَّنَا وَلَا تُحَمِّلْنَا مَا لَا طَاقَةَ لَنَا بِهِ وَاعْفُ عَنَّا وَاغْفِرْ لَنَا وَارْحَمْنَا أَنتَ مَوْلَانَا فَانصُرْنَا عَلَى الْقَوْمِ الْكَافِرِينَ',
+		latin:
+			'Lillaahi maa fis-samaawaati wa maa fil-ardh, wa in tubduu maa fii anfusikum aw tukhfuuhu yuhaasibkum bihillaah, fa yaghfiru liman yasyaa’ wa yu’adzdzibu man yasyaa’, wallaahu ’alaa kulli syay’in qadiir. Aamanar-rasuulu bimaa unzila ilayhi mir rabbihii wal-mu’minuun, kullun aamana billaahi wa malaa’ikatihii wa kutubihii wa rusulih, laa nufarriqu bayna ahadim min rusulih, wa qaaluu sami’naa wa atha’naa, ghufraanaka rabbanaa wa ilaykal-mashiir. Laa yukallifullahu nafsan illaa wus’ahaa, lahaa maa kasabat wa ’alayhaa maktasabat, rabbanaa laa tu’aakhidznaa in nasiinaa aw akhtha’naa, rabbanaa wa laa tahmil ’alaynaa ishran kamaa hamaltahuu ’alal-ladziina min qablinaa, rabbanaa wa laa tuhammilnaa maa laa thaaqata lanaa bih, wa’fu ’annaa waghfir lanaa warhamnaa anta mawlaanaa fanshurnaa ’alal-qawmil-kaafiriin',
 		translation:
-			'Dengan menyebut nama Allah yang maha pengasih lagi maha penyayang. Alif lam mim. Demikian itu kitab ini tidak ada keraguan padanya. Sebagai petunjuk bagi mereka yang bertakwa. Yaitu mereka yang beriman kepada yang ghaib, yang mendirikan shalat, dan menafkahkan sebagian rezeki yang kami anugerahkan kepada mereka. Dan mereka yang beriman kepada kitab Al-Qur’an yang telah diturunkan kepadamu (Muhammad SAW) dan kitab-kitab yang telah diturunkan sebelumnya, serta mereka yakin akan adanya kehidupan akhirat. Mereka itulah yang tetap mendapat petunjuk dari tuhannya. Merekalah orang orang yang beruntung'
+			'Kepunyaan Allah-lah segala apa yang ada di langit dan di bumi. Dan jika kamu melahirkan apa yang ada di dalam hatimu atau kamu menyembunyikannya, niscaya Allah akan membuat perhitungan dengan kamu tentang perbuatanmu itu. Maka Allah mengampuni siapa yang dikehendaki-Nya dan menyiksa siapa yang dikehendaki-Nya. Rasul telah beriman kepada Al-Qur’an yang diturunkan kepadanya dari Tuhannya, demikian pula orang-orang yang beriman. Semuanya beriman kepada Allah, malaikat-malaikat-Nya, kitab-kitab-Nya dan rasul-rasul-Nya. Allah tidak membebani seseorang melainkan sesuai dengan kesanggupannya. Ya Tuhan kami, janganlah Engkau hukum kami jika kami lupa atau kami bersalah. Ya Tuhan kami, ampunilah kami dan rahmatilah kami. Engkaulah penolong kami, maka tolonglah kami terhadap kaum yang kafir.',
+		translationEn:
+			'To Allah belongs whatever is in the heavens and whatever is in the earth. Whether you show what is within yourselves or conceal it, Allah will bring you to account for it. Then He will forgive whom He wills and punish whom He wills, and Allah is over all things competent. The Messenger has believed in what was revealed to him from his Lord, and so have the believers. Allah does not burden a soul beyond that it can bear. Our Lord, do not impose blame upon us if we have forgotten or erred. Our Lord, forgive us, have mercy upon us. You are our protector, so give us victory over the disbelieving people.',
+		count: 1
 	},
 	{
 		id: 11,
-		title: 'Surat Al-Baqarah ayat 163',
-		arabic: 'وَاِلَهُكُمْ اِلَهٌ وَّاحِدٌ لاَ اِلَهَ اِلاَّ هُوَ الرَّحْمَنُ الرَّحِيمُ',
+		order: 11,
+		title: 'Al-Ahzab 56 + Shalawat Ibrahim',
+		arabic:
+			'إِنَّ اللَّهَ وَمَلَائِكَتَهُ يُصَلُّونَ عَلَى النَّبِيِّ يَا أَيُّهَا الَّذِينَ آمَنُوا صَلُّوا عَلَيْهِ وَسَلِّمُوا تَسْلِيمًا. اللَّهُمَّ صَلِّ عَلَى سَيِّدِنَا مُحَمَّدٍ وَعَلَى آلِ سَيِّدِنَا مُحَمَّدٍ كَمَا صَلَّيْتَ عَلَى سَيِّدِنَا إِبْرَاهِيمَ وَعَلَى آلِ سَيِّدِنَا إِبْرَاهِيمَ وَبَارِكْ عَلَى سَيِّدِنَا مُحَمَّدٍ وَعَلَى آلِ سَيِّدِنَا مُحَمَّدٍ كَمَا بَارَكْتَ عَلَى سَيِّدِنَا إِبْرَاهِيمَ وَعَلَى آلِ سَيِّدِنَا إِبْرَاهِيمَ فِي الْعَالَمِينَ إِنَّكَ حَمِيدٌ مَّجِيدٌ',
+		latin:
+			'Innallaaha wa malaa’ikatahuu yushalluuna ’alan-nabiyy, yaa ayyuhal-ladziina aamanuu shalluu ’alayhi wa sallimuu tasliimaa. Allaahumma shalli ’alaa sayyidinaa Muhammadin wa ’alaa aali sayyidinaa Muhammadin kamaa shallayta ’alaa sayyidinaa Ibraahiima wa ’alaa aali sayyidinaa Ibraahiima, wa baarik ’alaa sayyidinaa Muhammadin wa ’alaa aali sayyidinaa Muhammadin kamaa baarakta ’alaa sayyidinaa Ibraahiima wa ’alaa aali sayyidinaa Ibraahiima fil-’aalamiina innaka hamiidumm majiid',
 		translation:
-			'Dan Tuhan kalian adalah Tuhan yang maha esa. Tiada tuhan yang layak disembah kecuali Dia yang maha pengasih lagi maha penyayang'
+			'Sesungguhnya Allah dan para malaikat-Nya bershalawat untuk Nabi. Wahai orang-orang yang beriman, bershalawatlah kamu untuk Nabi dan ucapkanlah salam penghormatan kepadanya. Ya Allah, limpahkanlah shalawat kepada junjungan kami Muhammad dan kepada keluarga Muhammad, sebagaimana Engkau telah melimpahkan shalawat kepada junjungan kami Ibrahim dan kepada keluarga Ibrahim. Dan limpahkanlah berkat kepada junjungan kami Muhammad dan kepada keluarga Muhammad, sebagaimana Engkau telah melimpahkan berkat kepada junjungan kami Ibrahim dan kepada keluarga Ibrahim, di seluruh alam semesta. Sesungguhnya Engkau Maha Terpuji lagi Maha Mulia.',
+		translationEn:
+			'Indeed, Allah and His angels send blessing upon the Prophet. O you who have believed, ask blessing upon him and ask Him to grant him peace. O Allah, send prayers upon our master Muhammad and upon the family of our master Muhammad, as You sent prayers upon our master Ibrahim and upon the family of Ibrahim. And bless our master Muhammad and the family of our master Muhammad, as You blessed our master Ibrahim and the family of Ibrahim, among all the worlds. Indeed, You are Praiseworthy and Majestic.',
+		count: 1
 	},
 	{
 		id: 12,
-		title: 'Ayat Kursi (Surat Al-Baqarah ayat 255)',
+		order: 12,
+		title: 'Surat Yasin',
 		arabic:
-			'اللهُ لاَ اِلَهَ اِلاَّ هُوَ الْحَىُّ الْقَيُّومُ، لاَ تَاْ خُذُهُ سِنَةٌ وَلاَ نَوْمٌ، لَّهُ مَا فِى السَّمَوَاتِ وَمَا فِى الْاَرْضِ، مَنْ ذَا الَّذِى يَشْفَعُ عِنْدَهُ اِلاَّ بِاِذْنِهِ، يَعْلَمُ مَا بَينَ اَيْدِيْهِمِ وَمَا خَلْفَهُمْ، وَلاَ يُحْيِطُونَ بِشَيْءٍ مِّنْ عِلْمِهِ اِلاَّ بِمَا شَاءَ، وَسِعَ كُرْسِيُّهُ السَّمَوَاتِ وَالْاَرْضَ، وَلاَ يَئُودُهُ حِفْظُهُمُا، وَهُوَ الْعَلِىُّ الْعَظِيْمُ',
+			'يٰسٓ. وَالْقُرْاٰنِ الْحَكِيْمِ. اِنَّكَ لَمِنَ الْمُرْسَلِيْنَ. عَلٰى صِرَاطٍ مُّسْتَقِيْمٍ ...',
+		latin:
+			'Yaa siin. Wal-qur’aanil-hakiim. Innaka laminal-mursaliin. ’alaa shiraathim mustaqiim ...',
 		translation:
-			'Allah, tiada yang layak disembah kecuali Dia yang hidup kekal lagi berdiri sendiri. Tidak mengantuk dan tidak tidur. Milik-Nya apa yang ada di langit dan di bumi. Tiada yang dapat memberikan syafa’at di sisi-Nya kecuali dengan izin-Nya. Dia mengetahui apa yang ada di hadapan dan di belakang mereka. Mereka tidak mengetahui sesuatu dari ilmu-Nya kecuali apa yang dikehendaki-Nya. Kursi Allah meliputi langit dan bumi. Dia tidak merasa berat menjaga keduanya. Dia maha tinggi lagi maha agung'
+			'Ya Sin. Demi Al-Qur’an yang penuh hikmah. Sesungguhnya kamu adalah salah seorang dari para rasul. Yang berada di atas jalan yang lurus ...',
+		translationEn:
+			'Ya Sin. By the Qur’an, full of wisdom. Indeed you, are from among the messengers. On a straight path ...',
+		count: 1,
+		note: 'Surat Yasin dibaca lengkap sebagai bagian utama Tahlil',
+		noteEn: 'Surah Yasin is read in full as a main part of Tahlil',
+		href: '/36'
 	},
 	{
 		id: 13,
-		title: 'Surat Al-Baqarah ayat 284-286',
+		order: 13,
+		title: 'Tahlil — La ilaha illallah',
+		arabic: 'لَا إِلَهَ إِلَّا اللَّهُ',
+		latin: 'Laa ilaaha illallaah',
+		translation: 'Tiada Tuhan selain Allah',
+		translationEn: 'There is no deity except Allah',
+		count: 33,
+		note: 'Dibaca 33x atau 100x sesuai kebiasaan',
+		noteEn: 'Recited 33x or 100x according to custom'
+	},
+	{
+		id: 14,
+		order: 14,
+		title: 'Doa Tahlil',
 		arabic:
-			'لِلَّهِ مَا فِى السَّمَوَاتِ وَمَا فِى الْاَرْضِ. وَاِنْ تُبْدُوْا مَا فِى اَنْفُسِكُمْ اَوْ تَخْفُوْهُ يُحَاسِبْكُمْ بِهِ اللهُ. فَيَغْفِرُ لَمِنْ يَّشَاءُ وَيُعْذِّبُ مَنْ يَّشَاءُ. وَاللهُ عَلَى كُلِّ شَىْءٍ قَدِيْرٌ. اَمَنَ الرَّسُوْلُ بِمَا اُنْزِلَ اِلَيْهِ مِنْ رَّبِّهِ وَالْمُؤْمِنُوْنَ. كُلٌّ اَمَنَ بِاللهِ وَمَلَائِكَتِهِ وَكُتُبِهِ وَرُسُلِهِ. لَانًفَرِّقُ بَيْنَ اَحَدٍ مِّنْ رُّسُلِهِ. وَقَالُوْا سَمِعْنَا وَاَطَعْنَا غُفْرَانَكَ رَبَّنَا وَاِلَيْكَ الْمَصِيْرُ. لَا يُكَلِّفُ اللهُ نَفْسًا اِلَّا وُسْعَهَا. لَهَا مَا كَسَبَتْ وَعَلَيْهَا مَا اكَتْسَبَتْ. رَبَّنَا لَا تُؤَاخِذْنَا اِنْ نَسِيْنَا اَوْ اَخْطَاْنَا. رَبَّنَا وَلَا تَحْمِلْ عَلَيْنَا اِصْرًا كَمَا حَمَلْتَهُ عَلَى الَّذِيْنَ مِنْ قَبْلِنَا. رَبَّنَا وَلَا تُحَمِّلْنَا مَا لَا طَاقَةَ لَنَا بِهِ. وَاعْفُ عَنَّا وَاغْفِرْ لَنَا وَارْحَمْنَا اَنْتَ مَوْلَانَا فَانْصُرْنَا عَلَى الْقَوْمِ الْكَافِرِيْنَ',
+			'اللَّهُمَّ أَوْصِلْ ثَوَابَ مَا قَرَأْنَاهُ مِنَ الْقُرْآنِ الْعَظِيمِ وَمَا هَلَّلْنَا وَمَا سَبَّحْنَا وَمَا اسْتَغْفَرْنَا وَمَا صَلَّيْنَا إِلَى رُوحِ سَيِّدِنَا مُحَمَّدٍ صَلَّى اللَّهُ عَلَيْهِ وَسَلَّمَ وَإِلَى أَرْوَاحِ آبَائِنَا وَأُمَّهَاتِنَا وَأُسْتَاذِنَا وَمَشَايِخِنَا وَمَنْ أَحسَنَ إِلَيْنَا وَإِلَى جَمِيعِ الْمُسْلِمِينَ وَالْمُسْلِمَاتِ الْأَحَياءِ مِنْهُمْ وَالْأَمْوَاتِ',
+		latin:
+			'Allaahumma awshil tsawaaba maa qara’naahu minal-qur’aanil-’azhiim wa maa hallalnaa wa maa sabbahnaa wa masta-ghfarnaa wa maa shallaynaa ilaa ruuhi sayyidinaa Muhammadin shallallaahu ’alayhi wa sallam wa ilaa arwaahi aabaainaa wa ummahaaatinaa wa asaatidzi-naa wa masyaayikhinaa wa man ahsana ilaynaa wa ilaa jamii’il-muslimiinawal-muslimaat al-ahyaai minhum wal-amwaat',
 		translation:
-			'Hanya milik Allah segala yang ada di langit dan yang ada di bumi. Jika kamu menyatakan atau merahasiakan apa saja yang di hatimu, maka kamu dengan itu semua tetap akan diperhitungkan oleh Allah. Dia akan mengampuni dan menyiksa orang yang dikehendaki. Allah maha kuasa atas segala sesuatu. Rasulullah dan orang-orang yang beriman mempercayai apa saja yang diturunkan kepadanya dari Tuhannya. Semuanya beriman kepada Allah, para malaikat-Nya, kitab-kitab-Nya, dan kepada para utusan-Nya. ‘Kami tidak membeda-bedakan seorang rasul dari lainnya.’ Mereka berkata, ‘Kami mendengar dan kami menaati. Ampunan-Mu, wahai Tuhan kami, yang kami harapkan. Hanya kepada-Mu tempat kembali.’ Allah tidak membebani seseorang kecuali dengan kemampuannya. Ia mendapat balasan atas apa yang dia perbuat dan siksaan dari apa yang dia lakukan. ‘Tuhan kami, janganlah Kau siksa kami jika kami terlupa atau salah. Tuhan kami, jangan Kau tanggungkan pada kami dengan beban berat sebagaimana Kaubebankan kaum sebelum kami. Jangan pula Kaubebankan pada kami sesuatu yang kami tidak mampu. Ampunilah kami. Kasihanilah kami. Kau pemimpin kami. Tolonglah kami menghadapi golongan kafir'
+			'Ya Allah, sampaikanlah pahala dari apa yang telah kami baca dari Al-Qur’an yang agung, tahlil, tasbih, istighfar, dan shalawat kepada ruh junjungan kami Muhammad SAW, kepada arwah ayah-ibu kami, guru-guru kami, masyayikh kami, orang-orang yang telah berbuat baik kepada kami, dan kepada seluruh muslimin dan muslimat, yang masih hidup maupun yang sudah meninggal.',
+		translationEn:
+			'O Allah, convey the reward of what we have recited from the Noble Qur’an, our tahlil, tasbih, istighfar, and salawat, to the soul of our master Muhammad (peace be upon him), to the souls of our fathers and mothers, our teachers, our scholars, those who have been good to us, and to all Muslim men and women, both the living and the deceased.',
+		count: 1
 	}
 ];
 
-export default {
-	source,
+const tahlil = {
+	data: tahlilData,
 	basedOn,
-	data: tahlilData
+	source
 };
+
+export default tahlil;

--- a/src/data/wirid.ts
+++ b/src/data/wirid.ts
@@ -1,133 +1,284 @@
 export type WiridItem = {
 	id: number;
-	times: number;
+	order: number;
+	title: string;
 	arabic: string;
-	tnc: string;
+	latin: string;
+	translation: string;
+	translationEn: string;
+	count: number;
+	note?: string;
+	noteEn?: string;
 };
 
-const source =
-	'https://islam.nu.or.id/post/read/79315/susunan-bacaan-wirid-sesudah-shalat-lima-waktu';
+const source = 'https://islam.nu.or.id/shalat/susunan-bacaan-wirid-sesudah-shalat-lima-waktu';
+const basedOn = 'Majmu’ Syarif (NU)';
 
 const wiridData: WiridItem[] = [
 	{
 		id: 1,
-		times: 3,
+		order: 1,
+		title: 'Istighfar',
 		arabic:
-			'أَسْتَغْفِرُ اللهَ الْعَظِـيْمِ الَّذِيْ لَااِلَهَ اِلَّا هُوَ الْحَيُّ الْقَيُّوْمُ وَأَتُوْبُ إِلَيْهِ ',
-		tnc: ''
+			'’أَسْتَغْفِرُ اللهَ الْعَظِيمَ الَّذِي لَا إِلَهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ وَأَتُوبُ إِلَيْهِ',
+		latin:
+			'Astaghfirullaahal-’azhiim alladzii laa ilaaha illaa huwal hayyul qayyuumu wa atuubu ilaih',
+		translation:
+			'Aku memohon ampun kepada Allah Yang Maha Agung, tiada Tuhan selain Dia, yang Maha Hidup lagi Maha Berdiri Sendiri, dan aku bertaubat kepada-Nya.',
+		translationEn:
+			'I seek forgiveness from Allah the Almighty, besides Whom there is no deity, the Ever-Living, the Sustainer of existence, and I repent to Him.',
+		count: 3
 	},
 	{
 		id: 2,
-		times: 1,
+		order: 2,
+		title: 'Allahumma Antas Salam',
 		arabic:
-			'اَللَّهُمَّ أَنْتَ السَّلاَمُ وَمِنْكَ السَّلَامُ تَبَارَكْتَ يَا ذَاالْـجَلَالِ وَاْلإِكْرَام',
-		tnc: ''
+			'اَللَّهُمَّ أَنْتَ السَّلَامُ وَمِنْكَ السَّلَامُ تَبَارَكْتَ يَا ذَا الْجَلَالِ وَالْإِكْرَامِ',
+		latin: 'Allaahumma antas-salaamu wa minkas-salaam, tabaarakta yaa dzal-jalaali wal-ikraam',
+		translation:
+			'Ya Allah, Engkau adalah As-Salam, dan dari-Mu datang keselamatan. Maha Berkah Engkau wahai Pemilik keagungan dan kemuliaan.',
+		translationEn:
+			'O Allah, You are As-Salam (the source of peace), and from You comes peace. Blessed are You, O Possessor of majesty and honor.',
+		count: 1
 	},
 	{
 		id: 3,
-		times: 1,
+		order: 3,
+		title: 'Allahumma Laa Mani’a',
 		arabic:
-			'اَللَّهُمَّ لَا مَانِعَ لِمَا أَعْطَيْتَ، وَلاَ مُعْطِيَ لِمَا مَنَعْتَ، وَلَا يَنْفَعُ ذَاالْجَدِّ مِنْكَ الْجَدُّ',
-		tnc: ''
+			'اَللَّهُمَّ لَا مَانِعَ لِمَا أَعْطَيْتَ وَلَا مُعْطِيَ لِمَا مَنَعْتَ وَلَا يَنْفَعُ ذَا الْجَدِّ مِنْكَ الْجَدُّ',
+		latin:
+			'Allaahumma laa maani’a limaa a’thaita, wa laa mu’thiya limaa mana’ta, wa laa yanfa’u dzal-jaddi minkal-jadd',
+		translation:
+			'Ya Allah, tidak ada yang bisa menghalangi apa yang Engkau berikan, dan tidak ada yang bisa memberi apa yang Engkau cegah, dan kekayaan orang kaya tidak bermanfaat di sisi-Mu.',
+		translationEn:
+			'O Allah, none can withhold what You have given, none can give what You have withheld, and no wealth of the wealthy can avail them before You.',
+		count: 1
 	},
 	{
 		id: 4,
-		times: 1,
-		arabic: 'اَللَّـهُمَّ اَعِنِّي عَلَى ذِكْرِكَ وَشُكْرِكَ وَحُسْنِ عِبَادَتِكَ',
-		tnc: ''
+		order: 4,
+		title: 'Allahumma A’inni',
+		arabic: 'اَللَّهُمَّ أَعِنِّي عَلَى ذِكْرِكَ وَشُكْرِكَ وَحُسْنِ عِبَادَتِكَ',
+		latin: 'Allaahumma a’innii ’alaa dzikrika wa syukrika wa husni ’ibaadatik',
+		translation:
+			'Ya Allah, bantulah aku dalam mengingat-Mu, bersyukur kepada-Mu, dan beribadah kepada-Mu dengan baik.',
+		translationEn:
+			'O Allah, help me to remember You, to thank You, and to worship You in the best manner.',
+		count: 1
 	},
 	{
 		id: 5,
-		times: 3,
+		order: 5,
+		title: 'Tahlil',
 		arabic:
-			'لَاإِلَهَ إِلَّا اللهُ وَحْدَهُ لَا شَرِيْكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ يُحْيِيْ وَيُمِيْتُ وَهُوَ عَلَى كُلِّ شَيْئٍ قَدِيْرٌ',
-		tnc: '(dibaca tiga kali tiap selesai shalat fardhu, khusus setelah maghrib dan shubuh sepuluh kali)'
+			'لَا إِلَهَ إِلَّا اللهُ وَحْدَهُ لَا شَرِيكَ لَهُ لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ يُحْيِي وَيُمِيتُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيرٌ',
+		latin:
+			'Laa ilaaha illallaahu wahdahu laa syariika lah, lahul-mulku wa lahul-hamdu, yuhyii wa yumiitu wa huwa ’alaa kulli syay’in qadiir',
+		translation:
+			'Tiada Tuhan selain Allah semata, tiada sekutu bagi-Nya. Milik-Nya kerajaan dan segala pujian. Dia yang menghidupkan dan mematikan, dan Dia Maha Kuasa atas segala sesuatu.',
+		translationEn:
+			'There is no deity but Allah alone, without partner. To Him belongs the kingdom and all praise. He gives life and causes death, and He is Able to do all things.',
+		count: 3,
+		note: 'Dibaca 3x setiap selesai shalat fardhu, khusus setelah Maghrib dan Subuh 10x',
+		noteEn: 'Read 3x after each obligatory prayer; 10x after Maghrib and Fajr'
 	},
 	{
 		id: 6,
-		times: 7,
-		arabic: 'اَللَّهُمَّ أَجِرْنِـى مِنَ النَّارِ',
-		tnc: '(tujuh kali bakda maghrib dan shubuh)'
+		order: 6,
+		title: 'Allahumma Ajirni Minan Nar',
+		arabic: 'اَللَّهُمَّ أَجِرْنِي مِنَ النَّارِ',
+		latin: 'Allaahumma ajirni minan-naar',
+		translation: 'Ya Allah, selamatkanlah aku dari api neraka.',
+		translationEn: 'O Allah, protect me from the Fire of Hell.',
+		count: 7,
+		note: 'Dibaca 7x setelah Maghrib dan Subuh',
+		noteEn: 'Read 7x after Maghrib and Fajr'
 	},
 	{
 		id: 7,
-		times: 1,
+		order: 7,
+		title: 'Ayat Kursi (Al-Baqarah: 255)',
 		arabic:
-			'أَعُوذُ بِاللَّهِ مِنَ الشَّيْطَانِ الرَّجِيمِ. بِسْمِ اللهِ الرَّحْمَنِ الرَّحِيْمِ. اَللهُ لَا إِلَهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ لَا تَأْخُذُهُ سِنَةٌ وَّلَانَوْمٌ، لَهُ مَافِي السَّمَاوَاتِ وَمَافِي اْلأَرْضِ مَن ذَا الَّذِيْ يَشْفَعُ عِنْدَهُ إِلَّا بِإِذْنِهِ يَعْلَمُ مَابَيْنَ أَيْدِيْهِمْ وَمَاخَلْفَهُمْ وَلَا يُحِيْطُونَ بِشَيْءٍ مِّنْ عِلْمِهِ إِلَّا بِمَا شَآءَ، وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَاْلأَرْضَ وَلَا يَـؤدُهُ حِفْظُهُمَا وَهُوَ الْعَلِيُّ الْعَظِيْمُ',
-		tnc: ''
+			'اَللهُ لَا إِلَهَ إِلَّا هُوَ الْحَيُّ الْقَيُّومُ لَا تَأْخُذُهُ سِنَةٌ وَلَا نَوْمٌ لَهُ مَا فِي السَّمَاوَاتِ وَمَا فِي الْأَرْضِ مَنْ ذَا الَّذِي يَشْفَعُ عِنْدَهُ إِلَّا بِإِذْنِهِ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ وَلَا يُحِيطُونَ بِشَيْءٍ مِنْ عِلْمِهِ إِلَّا بِمَا شَاءَ وَسِعَ كُرْسِيُّهُ السَّمَاوَاتِ وَالْأَرْضَ وَلَا يَئُودُهُ حِفْظُهُمَا وَهُوَ الْعَلِيُّ الْعَظِيمُ',
+		latin:
+			'Allaahu laa ilaaha illaa huwal-hayyul-qayyuum, laa ta’khudzuhu sinatuw wa laa naum, lahuu maa fis-samaawaati wa maa fil-ardh, man dzal-ladzii yasyfa’u ’indahuu illaa bi’idznih, ya’lamu maa bayna aydiihim wa maa khalfahum, wa laa yuhiithuuna bisyay’im min ’ilmihii illaa bimaa syaa’, wasi’a kursiyyuhus-samaawaati wal-ardha, wa laa ya’uuduhu hifzhuhumaa, wa huwal-’aliyyul-’azhiim',
+		translation:
+			'Allah, tiada Tuhan selain Dia, yang Maha Hidup lagi Maha Berdiri Sendiri. Tidak mengantuk dan tidak tidur. Milik-Nya apa yang ada di langit dan di bumi. Tidak ada yang dapat memberi syafaat kecuali dengan izin-Nya. Kursi-Nya meliputi langit dan bumi. Menjaga keduanya tidak memberatkan-Nya. Dan Dialah yang Maha Tinggi lagi Maha Agung.',
+		translationEn:
+			'Allah — there is no deity except Him, the Ever-Living, the Sustainer of existence. Neither drowsiness overtakes Him nor sleep. To Him belongs whatever is in the heavens and on the earth. His Kursi extends over the heavens and the earth, and their preservation tires Him not. He is the Most High, the Most Great.',
+		count: 1
 	},
 	{
 		id: 8,
-		times: 1,
+		order: 8,
+		title: 'Al-Baqarah ayat 285-286',
 		arabic:
-			'آمَنَ الرَّسُولُ بِمَا أُنْزِلَ إِلَيْهِ مِنْ رَبِّهِ وَالْمُؤْمِنُونَ، كُلٌّ آمَنَ بِاللَّهِ وَمَلَائِكَتِهِ وَكُتُبِهِ وَرُسُلِهِ لَا نُفَرِّقُ بَيْنَ أَحَدٍ مِنْ رُسُلِهِ، وَقَالُوا سَمِعْنَا وَأَطَعْنَا غُفْرَانَكَ رَبَّنَا وَإِلَيْكَ الْمَصِيرُ. لَا يُكَلِّفُ اللَّهُ نَفْسًا إِلَّا وُسْعَهَا، لَهَا مَا كَسَبَتْ وَعَلَيْهَا مَا اكْتَسَبَتْ. رَبَّنَا لَا تُؤَاخِذْنَا إِنْ نَسِينَا أَوْ أَخْطَأْنَا، رَبَّنَا وَلَا تَحْمِلْ عَلَيْنَا إِصْرًا كَمَا حَمَلْتَهُ عَلَى الَّذِينَ مِنْ قَبْلِنَا، رَبَّنَا وَلَا تُحَمِّلْنَا مَا لَا طَاقَةَ لَنَا بِهِ، وَاعْفُ عَنَّا وَاغْفِرْ لَنَا وَارْحَمْنَا، أَنْتَ مَوْلَانَا فَانْصُرْنَا عَلَى الْقَوْمِ الْكَافِرِينَ',
-		tnc: ''
+			'آمَنَ الرَّسُولُ بِمَا أُنزِلَ إِلَيْهِ مِن رَّبِّهِ وَالْمُؤْمِنُونَ كُلٌّ آمَنَ بِاللَّهِ وَمَلَائِكَتِهِ وَكُتُبِهِ وَرُسُلِهِ لَا نُفَرِّقُ بَيْنَ أَحَدٍ مِّن رُّسُلِهِ وَقَالُوا سَمِعْنَا وَأَطَعْنَا غُفْرَانَكَ رَبَّنَا وَإِلَيْكَ الْمَصِيرُ. لَا يُكَلِّفُ اللَّهُ نَفْسًا إِلَّا وُسْعَهَا لَهَا مَا كَسَبَتْ وَعَلَيْهَا مَا اكْتَسَبَتْ رَبَّنَا لَا تُؤَاخِذْنَا إِن نَّسِينَا أَوْ أَخْطَأْنَا رَبَّنَا وَلَا تَحْمِلْ عَلَيْنَا إِصْرًا كَمَا حَمَلْتَهُ عَلَى الَّذِينَ مِن قَبْلِنَا رَبَّنَا وَلَا تُحَمِّلْنَا مَا لَا طَاقَةَ لَنَا بِهِ وَاعْفُ عَنَّا وَاغْفِرْ لَنَا وَارْحَمْنَا أَنتَ مَوْلَانَا فَانصُرْنَا عَلَى الْقَوْمِ الْكَافِرِينَ',
+		latin:
+			'Aamanar-rasuulu bimaa unzila ilayhi mir-rabbihii wal-mu’minuun, kullun aamana billaahi wa malaa’ikatihii wa kutubihii wa rusulih, laa nufarriqu bayna ahadin mir-rusulih, wa qaaluu sami’naa wa atha’naa, ghufraanaka rabbanaa wa ilaykal-masiir. Rabbanaa laa tu’aakhidznaa in nasiinaa aw akhtha’naa, wa’fu ’annaa waghfir lanaa warhamnaa, anta mawlaanaa fanshurnaa ’alal-qawmil-kaafiriin',
+		translation:
+			'Rasul telah beriman kepada apa yang diturunkan kepadanya dari Tuhannya, dan demikian pula orang-orang beriman. Semuanya beriman kepada Allah, malaikat-malaikat-Nya, kitab-kitab-Nya, dan rasul-rasul-Nya. Ya Tuhan kami, ampuni kami, sayangi kami. Engkaulah pelindung kami, tolonglah kami menghadapi orang-orang kafir.',
+		translationEn:
+			'The Messenger has believed in what was revealed to him from his Lord, and so have the believers. Our Lord, forgive us, have mercy upon us. You are our protector, so give us victory over the disbelieving people.',
+		count: 1
 	},
 	{
 		id: 9,
-		times: 1,
+		order: 9,
+		title: 'Ali Imran 18 & 26-27',
 		arabic:
-			'شَهِدَ اللَّهُ أَنَّهُ لَا إِلَٰهَ إِلَّا هُوَ وَالْمَلَائِكَةُ وَأُولُو الْعِلْمِ قَائِمًا بِالْقِسْطِ، لَا إِلَٰهَ إِلَّا هُوَ الْعَزِيزُ الْحَكِيمُ، إِنَّ الدِّينَ عِنْدَ اللَّهِ الْإِسْلَامُ، قُلِ اللَّهُمَّ مَالِكَ الْمُلْكِ تُؤْتِي الْمُلْكَ مَنْ تَشَاءُ وَتَنْزِعُ الْمُلْكَ مِمَّنْ تَشَاءُ وَتُعِزُّ مَنْ تَشَاءُ وَتُذِلُّ مَنْ تَشَاءُ، بِيَدِكَ الْخَيْرُ،  إِنَّكَ عَلَىٰ كُلِّ شَيْءٍ قَدِيرٌ. تُولِجُ اللَّيْلَ فِي النَّهَارِ وَتُولِجُ النَّهَارَ فِي اللَّيْلِ، وَتُخْرِجُ الْحَيَّ مِنَ الْمَيِّتِ وَتُخْرِجُ الْمَيِّتَ مِنَ الْحَيِّ، وَتَرْزُقُ مَنْ تَشَاءُ بِغَيْرِ حِسَابٍ',
-		tnc: ''
+			'شَهِدَ اللَّهُ أَنَّهُ لَا إِلَٰهَ إِلَّا هُوَ وَالْمَلَائِكَةُ وَأُولُو الْعِلْمِ قَائِمًا بِالْقِسْطِ لَا إِلَٰهَ إِلَّا هُوَ الْعَزِيزُ الْحَكِيمُ إِنَّ الدِّينَ عِندَ اللَّهِ الْإِسْلَامُ. قُلِ اللَّهُمَّ مَالِكَ الْمُلْكِ تُؤْتِي الْمُلْكَ مَن تَشَاءُ وَتَنزِعُ الْمُلْكَ مِمَّن تَشَاءُ وَتُعِزُّ مَن تَشَاءُ وَتُذِلُّ مَن تَشَاءُ بِيَدِكَ الْخَيْرُ إِنَّكَ عَلَىٰ كُلِّ شَيْءٍ قَدِيرٌ تُولِجُ اللَّيْلَ فِي النَّهَارِ وَتُولِجُ النَّهَارَ فِي اللَّيْلِ وَتُخْرِجُ الْحَيَّ مِنَ الْمَيِّتِ وَتُخْرِجُ الْمَيِّتَ مِنَ الْحَيِّ وَتَرْزُقُ مَن تَشَاءُ بِغَيْرِ حِسَابٍ',
+		latin:
+			'Syahidallaahu annahuu laa ilaaha illaa huwa wal-malaa’ikatu wa ulul-’ilmi qaa’iman bil-qisth, laa ilaaha illaa huwal-’aziizul-hakiim, innad-diina ’indallaahil-islaam. Qulillaahuma maalikal-mulki tu’til-mulka man tasyaa’u, wa tu’izzu man tasyaa’u wa tudzillu man tasyaa’u, biyadikal-khayr, innaka ’alaa kulli syay’in qadiir. Tuulijul-layla fin-nahaari wa tuulijun-nahaara fil-layl, wa tarzuqu man tasyaa’u bighayri hisaab',
+		translation:
+			'Allah menyatakan bahwa tiada Tuhan selain Dia, dan para malaikat serta orang-orang berilmu menegakkan keadilan. Tiada Tuhan selain Dia yang Maha Perkasa lagi Maha Bijaksana. Katakanlah: Ya Allah, Pemilik kerajaan, Engkau berikan kerajaan kepada siapa yang Engkau kehendaki. Engkau masukkan malam ke dalam siang dan siang ke dalam malam. Engkau beri rezeki tanpa batas.',
+		translationEn:
+			'Allah witnesses that there is no deity except Him, and so do the angels and those of knowledge. There is no deity except Him, the Exalted in Might, the Wise. Say: O Allah, Owner of Sovereignty, You give sovereignty to whom You will. You cause the night to enter the day and You give sustenance without account.',
+		count: 1
 	},
 	{
 		id: 10,
-		times: 1,
-		arabic: 'Membaca Surat al-Ikhlas, Surat al-Falaq, Surat an-Nas, lalu Surat al-Fatihah',
-		tnc: ''
+		order: 10,
+		title: 'Surat Al-Ikhlas',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ هُوَ اللَّهُ أَحَدٌ. اللَّهُ الصَّمَدُ. لَمْ يَلِدْ وَلَمْ يُولَدْ. وَلَمْ يَكُن لَّهُ كُفُوًا أَحَدٌ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul huwallaahu ahad. Allaahus-shamad. Lam yalid wa lam yuulad. Wa lam yakul lahuu kufuwan ahad',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Dialah Allah, Yang Maha Esa. Allah adalah Tuhan yang bergantung kepada-Nya segala urusan. Dia tiada beranak dan tiada pula diperanakkan. Dan tidak ada seorangpun yang setara dengan Dia.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: He is Allah, the One. Allah, the Eternal Refuge. He neither begets nor is born. Nor is there to Him any equivalent.',
+		count: 1
 	},
 	{
 		id: 11,
-		times: 33,
-		arabic: 'سُبْحَانَ اللهِ ×٣٣ ',
-		tnc: ''
+		order: 11,
+		title: 'Surat Al-Falaq',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ أَعُوذُ بِرَبِّ الْفَلَقِ. مِن شَرِّ مَا خَلَقَ. وَمِن شَرِّ غَاسِقٍ إِذَا وَقَبَ. وَمِن شَرِّ النَّفَّاثَاتِ فِي الْعُقَدِ. وَمِن شَرِّ حَاسِدٍ إِذَا حَسَدَ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul a’uudzu birabbil-falaq. Min syarri maa khalaq. Wa min syarri ghaasiqin idzaa waqab. Wa min syarrin-naffaatsaati fil-’uqad. Wa min syarri haasidin idzaa hasad',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Aku berlindung kepada Tuhan yang menguasai fajar. Dari kejahatan makhluk-Nya, dari kejahatan malam apabila telah gelap gulita, dari kejahatan wanita-wanita tukang sihir, dan dari kejahatan orang yang dengki apabila ia dengki.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: I seek refuge in the Lord of daybreak from the evil of that which He created, and from the evil of darkness when it settles, and from the evil of the blowers in knots, and from the evil of an envier when he envies.',
+		count: 1
 	},
 	{
 		id: 12,
-		times: 33,
-		arabic: 'اَلْحَمْدُلِلهِ ×٣٣',
-		tnc: ''
+		order: 12,
+		title: 'Surat An-Nas',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. قُلْ أَعُوذُ بِرَبِّ النَّاسِ. مَلِكِ النَّاسِ. إِلَٰهِ النَّاسِ. مِن شَرِّ الْوَسْوَاسِ الْخَنَّاسِ. الَّذِي يُوَسْوِسُ فِي صُدُورِ النَّاسِ. مِنَ الْجِنَّةِ وَالنَّاسِ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Qul a’uudzu birabbin-naas. Malikin-naas. Ilaahin-naas. Min syarril-waswaasil-khannaas. Alladzii yuwaswisu fii shuduurin-naas. Minal-jinnati wan-naas',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Katakanlah: Aku berlindung kepada Tuhan manusia, Raja manusia, Sembahan manusia, dari kejahatan bisikan setan yang biasa bersembunyi, yang membisikkan kejahatan ke dalam dada manusia, dari golongan jin dan manusia.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. Say: I seek refuge in the Lord of mankind, the Sovereign of mankind, the God of mankind, from the evil of the retreating whisperer who whispers in the breasts of mankind, from among the jinn and mankind.',
+		count: 1
 	},
 	{
 		id: 13,
-		times: 33,
-		arabic: 'اَللهُ اَكْبَرْ ×٣٣',
-		tnc: ''
+		order: 13,
+		title: 'Surat Al-Fatihah',
+		arabic:
+			'بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ. الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ. الرَّحْمَٰنِ الرَّحِيمِ. مَالِكِ يَوْمِ الدِّينِ. إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ. اهْدِنَا الصِّرَاطَ الْمُسْتَقِيمَ. صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلَا الضَّالِّينَ',
+		latin:
+			'Bismillaahir-rahmaanir-rahiim. Alhamdu lillaahi rabbil-’aalamiin. Ar-rahmaanir-rahiim. Maaliki yawmid-diin. Iyyaaka na’budu wa iyyaaka nasta’iin. Ihdinash-shiraathal-mustaqiim. Shiraathal-ladziina an’amta ’alayhim, ghayril-maghdhuubi ’alayhim wa ladhdhaalliin',
+		translation:
+			'Dengan nama Allah Yang Maha Pengasih lagi Maha Penyayang. Segala puji bagi Allah, Tuhan semesta alam. Yang Maha Pengasih lagi Maha Penyayang. Yang menguasai hari pembalasan. Hanya kepada-Mu kami menyembah, dan hanya kepada-Mu kami memohon pertolongan. Tunjukkanlah kami ke jalan yang lurus. Yaitu jalan orang-orang yang Engkau beri nikmat, bukan jalan mereka yang dimurkai dan bukan pula jalan mereka yang sesat.',
+		translationEn:
+			'In the name of Allah, the Most Gracious, the Most Merciful. All praise is due to Allah, Lord of the worlds. The Most Gracious, the Most Merciful. Sovereign of the Day of Recompense. It is You we worship and You we ask for help. Guide us to the straight path — the path of those upon whom You have bestowed favor, not of those who have earned anger or of those who are astray.',
+		count: 1
 	},
 	{
 		id: 14,
-		times: 1,
-		arabic:
-			'اَللهُ اَكْبَرْ كَبِيْرًا وَالْحَمْدُ لِلهِ كَثِيْرًا وَسُبْحَانَ اللهِ بُكْرَةً وَأَصِيْلًا، لَاإِلَهَ إِلَّا اللهُ وَحْدَهُ لَا شَرِيْكَ لَهُ، لَهُ الْمُلْكُ وَلَهُ الْحَمْدُيُحْيِيْ وَيُمِيْتُ وَهُوَ عَلَى كُلِّ شَيْئٍ قَدِيْرٌ، وَلَاحَوْلَ وَلَاقُوَّةَ إِلَّابِا للهِ الْعَلِـىِّ الْعَظِيْمِ. ',
-		tnc: ''
+		order: 14,
+		title: 'Tasbih — Subhanallah',
+		arabic: 'سُبْحَانَ اللهِ',
+		latin: 'Subhaanallaah',
+		translation: 'Maha Suci Allah.',
+		translationEn: 'Glory be to Allah.',
+		count: 33
 	},
 	{
 		id: 15,
-		times: 1,
-		arabic: 'أَفْضَلُ ذِكْرِ فَاعْلَمْ أَنَّهُ',
-		tnc: ''
+		order: 15,
+		title: 'Tahmid — Alhamdulillah',
+		arabic: 'اَلْحَمْدُ لِلهِ',
+		latin: 'Alhamdulillaah',
+		translation: 'Segala puji bagi Allah.',
+		translationEn: 'All praise is due to Allah.',
+		count: 33
 	},
 	{
 		id: 16,
-		times: 100,
-		arabic: ' لَاإِلَهَ إِلَّا اللهُ ',
-		tnc: '(Dibaca 300 kali bakda shubuh, 100 kali bakda isya, 50 kali bakda dhuhur, 50 kali bakda ashar, dan 100 kali bakda maghrib)'
+		order: 16,
+		title: 'Takbir — Allahu Akbar',
+		arabic: 'اَللهُ أَكْبَرُ',
+		latin: 'Allaahu Akbar',
+		translation: 'Allah Maha Besar.',
+		translationEn: 'Allah is the Greatest.',
+		count: 33
 	},
 	{
 		id: 17,
-		times: 100,
-		arabic: 'صَلَّى اللهُ عَلَى مُحَمَّدٍ',
-		tnc: '(dibaca bakda shubuh 300 atau 100 kali)'
+		order: 17,
+		title: 'Allahu Akbar Kabira',
+		arabic:
+			'اَللهُ أَكْبَرُ كَبِيرًا وَالْحَمْدُ لِلهِ كَثِيرًا وَسُبْحَانَ اللهِ بُكْرَةً وَأَصِيلًا لَا إِلَهَ إِلَّا اللهُ وَحْدَهُ لَا شَرِيكَ لَهُ لَهُ الْمُلْكُ وَلَهُ الْحَمْدُ يُحْيِي وَيُمِيتُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيرٌ وَلَا حَوْلَ وَلَا قُوَّةَ إِلَّا بِاللهِ الْعَلِيِّ الْعَظِيمِ',
+		latin:
+			'Allaahu Akbaru kabiiraa, walhamdu lillaahi katsiiraa, wa subhaanallaahi bukrataw wa ashiilaa. Laa ilaaha illallaahu wahdahu laa syariika lah, lahul-mulku wa lahul-hamdu, yuhyii wa yumiitu wa huwa ’alaa kulli syay’in qadiir. Wa laa hawla wa laa quwwata illaa billaahil-’aliyyil-’azhiim',
+		translation:
+			'Allah Maha Besar dengan kebesaran yang sempurna, segala puji bagi Allah dengan pujian yang banyak, dan Maha Suci Allah di waktu pagi dan petang. Tiada Tuhan selain Allah semata, tiada sekutu bagi-Nya. Tiada daya dan kekuatan kecuali dengan pertolongan Allah Yang Maha Tinggi lagi Maha Agung.',
+		translationEn:
+			'Allah is truly the Greatest, all praise in abundance is due to Allah, and glory be to Allah in the morning and evening. There is no deity but Allah alone, without partner. And there is no might or power except with Allah, the Most High, the Most Great.',
+		count: 1
 	},
 	{
 		id: 18,
-		times: 1,
-		arabic: 'لَاإِلَهَ إِلَّا اللهُ مُحَمَّدٌ رَسُوْلُ اللهِ صَلَّى اللهُ عَلَيْهِ وَسَلَّمَ',
-		tnc: ''
+		order: 18,
+		title: 'Tahlil — Laa Ilaaha Illallah',
+		arabic: 'لَا إِلَهَ إِلَّا اللهُ',
+		latin: 'Laa ilaaha illallaah',
+		translation: 'Tiada Tuhan selain Allah.',
+		translationEn: 'There is no deity but Allah.',
+		count: 100,
+		note: 'Dibaca 300x bakda Subuh, 100x bakda Isya, 50x bakda Dhuhur, 50x bakda Ashar, dan 100x bakda Maghrib',
+		noteEn:
+			'Read 300x after Fajr, 100x after Isha, 50x after Dhuhr, 50x after Asr, and 100x after Maghrib'
+	},
+	{
+		id: 19,
+		order: 19,
+		title: 'Shalawat — Shallallahu ’ala Muhammad',
+		arabic: 'صَلَّى اللهُ عَلَى مُحَمَّدٍ',
+		latin: 'Shallallaahu ’alaa Muhammadin',
+		translation: 'Semoga Allah mencurahkan rahmat kepada Nabi Muhammad.',
+		translationEn: 'May Allah bestow blessings upon Muhammad.',
+		count: 100,
+		note: 'Dibaca 300x atau 100x bakda Subuh',
+		noteEn: 'Read 300x or 100x after Fajr'
+	},
+	{
+		id: 20,
+		order: 20,
+		title: 'Penutup',
+		arabic: 'لَا إِلَهَ إِلَّا اللهُ مُحَمَّدٌ رَسُولُ اللهِ صَلَّى اللهُ عَلَيْهِ وَسَلَّمَ',
+		latin: 'Laa ilaaha illallaahu Muhammadur-rasuulullaahi shallallaahu ’alayhi wa sallam',
+		translation:
+			'Tiada Tuhan selain Allah, Muhammad adalah utusan Allah, semoga Allah mencurahkan shalawat dan salam kepada beliau.',
+		translationEn:
+			'There is no deity but Allah, Muhammad is the Messenger of Allah, may Allah bestow peace and blessings upon him.',
+		count: 1
 	}
 ];
 
 export default {
 	source,
+	basedOn,
 	data: wiridData
 };

--- a/src/lib/ReadingCard.svelte
+++ b/src/lib/ReadingCard.svelte
@@ -1,0 +1,251 @@
+<script lang="ts">
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
+	import CheckIcon from '$lib/icons/CheckIcon.svelte';
+	import ResetIcon from '$lib/icons/ResetIcon.svelte';
+
+	interface ReadingItem {
+		id: number;
+		order: number;
+		title: string;
+		arabic: string;
+		latin: string;
+		translation: string;
+		translationEn: string;
+		count: number;
+		note?: string;
+		noteEn?: string;
+		href?: string;
+	}
+
+	interface Props {
+		item: ReadingItem;
+		count: number;
+		playMode?: boolean;
+		isLast?: boolean;
+		onIncrement: () => void;
+		onReset: () => void;
+		onNext?: () => void;
+	}
+
+	let {
+		item,
+		count,
+		playMode = false,
+		isLast = false,
+		onIncrement,
+		onReset,
+		onNext
+	}: Props = $props();
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+	const done = $derived(count >= item.count);
+	const remaining = $derived(Math.max(0, item.count - count));
+	const translation = $derived(isEnglish ? item.translationEn : item.translation);
+	const note = $derived(isEnglish ? (item.noteEn ?? '') : (item.note ?? ''));
+</script>
+
+<div
+	class="relative rounded-xl overflow-hidden bg-secondary shadow p-4 flex flex-col gap-3 border-2 transition-colors {done
+		? 'border-green-500'
+		: 'border-transparent'}"
+>
+	{#if playMode}
+		<!-- Play mode header -->
+		<div class="flex items-center justify-between gap-3">
+			<div class="flex items-center gap-3">
+				<div
+					class="w-12 h-12 rounded-full flex items-center justify-center font-bold text-xl shadow-md flex-shrink-0 transition-colors {done
+						? 'bg-green-500 dark:bg-green-600 text-white'
+						: 'bg-teal-600 dark:bg-teal-700 text-white'}"
+				>
+					{item.order}
+				</div>
+				{#if item.count > 1}
+					<span
+						class="text-sm px-2.5 py-1 rounded-full font-semibold tabular-nums whitespace-nowrap {done
+							? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
+							: 'bg-primary text-foreground/80'}"
+					>
+						{count} / {item.count}
+					</span>
+				{/if}
+				{#if done}
+					<CheckIcon size="md" class="text-green-500" />
+				{/if}
+			</div>
+			{#if !item.href}
+				<button
+					type="button"
+					onclick={onReset}
+					aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
+					class="cursor-pointer rounded-lg p-1.5 bg-primary border border-foreground/10 hover:border-foreground/30 opacity-50 hover:opacity-100 transition"
+				>
+					<ResetIcon size="sm" />
+				</button>
+			{/if}
+		</div>
+
+		<!-- Title -->
+		<p class="text-sm font-semibold opacity-70">{item.title}</p>
+	{:else}
+		<!-- All-mode header -->
+		<div class="flex items-start justify-between gap-3">
+			<div class="flex items-center gap-2 flex-wrap">
+				<div
+					class="w-7 h-7 rounded-full bg-primary border-2 border-foreground/20 flex items-center justify-center text-xs font-bold opacity-80 flex-shrink-0"
+				>
+					{item.order}
+				</div>
+				<span class="text-sm font-semibold opacity-80">{item.title}</span>
+			</div>
+			<div class="flex items-center gap-2 flex-shrink-0">
+				{#if item.count > 1}
+					<span
+						class="text-xs px-2 py-0.5 rounded-full font-semibold tabular-nums whitespace-nowrap {done
+							? 'bg-green-100 text-green-700 dark:bg-green-900/60 dark:text-green-200'
+							: 'bg-primary text-foreground/80'}"
+					>
+						{count} / {item.count}
+					</span>
+				{/if}
+				{#if done}
+					<CheckIcon size="md" class="text-green-500" />
+				{/if}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Arabic text -->
+	<p
+		dir="rtl"
+		lang="ar"
+		class="font-arabic leading-loose text-right {playMode ? 'text-3xl' : 'text-2xl'} {item.href
+			? 'opacity-40 text-xl'
+			: ''}"
+	>
+		{item.arabic}
+	</p>
+
+	<!-- Latin transliteration -->
+	{#if !item.href}
+		<p class="text-sm italic opacity-70 leading-relaxed">{item.latin}</p>
+	{/if}
+
+	<!-- Translation -->
+	<p class="text-sm opacity-90 leading-relaxed">{translation}</p>
+
+	{#if note}
+		<p class="text-xs opacity-60 leading-relaxed italic">{note}</p>
+	{/if}
+
+	<!-- Action area -->
+	{#if playMode}
+		<div class="mt-1">
+			{#if item.href}
+				<!-- Link card — open surah in app -->
+				<a
+					href={item.href}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="w-full flex items-center justify-center gap-2 cursor-pointer rounded-xl px-4 py-4 text-base font-bold border-2 transition active:scale-[0.98] bg-teal-600 dark:bg-teal-700 text-white border-teal-700 dark:border-teal-600 hover:bg-teal-700 dark:hover:bg-teal-800 shadow-md"
+				>
+					📖 {isEnglish ? 'Open Surah →' : 'Buka Surat →'}
+				</a>
+				<button
+					type="button"
+					onclick={onNext}
+					class="mt-2 w-full cursor-pointer rounded-xl px-4 py-3 text-sm font-semibold border-2 transition active:scale-[0.98] bg-primary border-foreground/20 hover:border-foreground/40"
+				>
+					{isEnglish ? 'Done, continue →' : 'Selesai, lanjut →'}
+				</button>
+			{:else if done && !isLast}
+				<button
+					type="button"
+					onclick={onNext}
+					class="w-full cursor-pointer rounded-xl px-4 py-4 text-lg font-bold border-2 transition active:scale-[0.98] bg-teal-600 dark:bg-teal-700 text-white border-teal-700 dark:border-teal-600 hover:bg-teal-700 dark:hover:bg-teal-800 shadow-md"
+				>
+					{isEnglish ? 'Next →' : 'Berikutnya →'}
+				</button>
+			{:else if done && isLast}
+				<div
+					class="w-full rounded-xl px-4 py-4 text-lg font-bold border-2 bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 text-center"
+				>
+					✓ {isEnglish ? 'All Complete!' : 'Semua Selesai!'}
+				</div>
+			{:else}
+				<button
+					type="button"
+					onclick={onIncrement}
+					aria-label={item.count > 1
+						? isEnglish
+							? `Count, ${count} of ${item.count}`
+							: `Hitung, ${count} dari ${item.count}`
+						: isEnglish
+							? 'Mark as done'
+							: 'Tandai selesai'}
+					class="w-full cursor-pointer rounded-xl px-4 py-4 text-lg font-bold border-2 transition active:scale-[0.98] bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground"
+				>
+					{#if item.count > 1}
+						{isEnglish ? 'Tap (+1)' : 'Tekan (+1)'}
+						<span class="text-sm font-normal opacity-60 ml-1">
+							({remaining}
+							{isEnglish ? 'more' : 'lagi'})
+						</span>
+					{:else}
+						{isEnglish ? '✓ Done' : '✓ Selesai'}
+					{/if}
+				</button>
+			{/if}
+		</div>
+	{:else}
+		<!-- All-mode actions -->
+		<div class="flex items-stretch gap-2 mt-1">
+			{#if item.href}
+				<a
+					href={item.href}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex-1 flex items-center justify-center gap-2 cursor-pointer rounded-lg px-4 py-3 text-sm font-semibold border-2 transition bg-teal-600 dark:bg-teal-700 text-white border-teal-700"
+				>
+					📖 {isEnglish ? 'Open Surah' : 'Buka Surat'}
+				</a>
+			{:else}
+				<button
+					type="button"
+					onclick={onIncrement}
+					disabled={done}
+					aria-label={done
+						? isEnglish
+							? 'Target reached'
+							: 'Target tercapai'
+						: item.count > 1
+							? isEnglish
+								? `Count, currently ${count} of ${item.count}`
+								: `Hitung, sekarang ${count} dari ${item.count}`
+							: isEnglish
+								? 'Mark as done'
+								: 'Tandai selesai'}
+					class="flex-1 cursor-pointer rounded-lg px-4 py-3 text-sm font-semibold border-2 transition active:scale-[0.98] {done
+						? 'bg-green-100 dark:bg-green-950 border-green-500 text-green-700 dark:text-green-300 cursor-not-allowed'
+						: 'bg-primary border-foreground/20 hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-foreground'}"
+				>
+					{#if done}
+						{isEnglish ? '✓ Done' : '✓ Selesai'}
+					{:else if item.count > 1}
+						{isEnglish ? `Tap (+1)` : 'Tekan (+1)'}
+					{:else}
+						{isEnglish ? 'Mark Done' : 'Tandai Selesai'}
+					{/if}
+				</button>
+				<button
+					type="button"
+					onclick={onReset}
+					aria-label={isEnglish ? 'Reset this counter' : 'Reset penghitung ini'}
+					class="cursor-pointer rounded-lg px-3 py-2 bg-secondary border-2 border-foreground/20 hover:border-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
+				>
+					<ResetIcon size="md" />
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/routes/tahlil/+page.svelte
+++ b/src/routes/tahlil/+page.svelte
@@ -1,21 +1,74 @@
 <script lang="ts">
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
-	import CardShadow from '$lib/CardShadow.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
+	import ReadingCard from '$lib/ReadingCard.svelte';
+	import Tabs from '$lib/ui/Tabs.svelte';
 	import { META_DESC_TAHLIL, META_TITLE_TAHLIL, TITLE_CONSTANTS } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
-	import DocumentTextIcon from '$lib/icons/DocumentTextIcon.svelte';
-	import Button from '$lib/ui/Button.svelte';
-	import tahlil, { type TahlilItem } from '../../data/tahlil';
-	import { globalBottomSheet } from '../../store/globalBottomSheet';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+	import tahlil from '../../data/tahlil';
 
-	let toggleBottomSheet = (item: TahlilItem) => {
-		globalBottomSheet.toggle({
-			title: `💠 Terjemahan: ${item.title}`,
-			content: `🔸 ${item.translation}`
-		});
-	};
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	const items = tahlil.data;
+	const total = items.length;
+
+	let playMode = $state(true);
+	let currentPlayIndex = $state(0);
+	let slideDir = $state(1);
+	let counts = $state<Record<number, number>>({});
+
+	const currentItem = $derived(currentPlayIndex < total ? items[currentPlayIndex] : null);
+	const completed = $derived(items.filter((i) => i.href || (counts[i.id] ?? 0) >= i.count).length);
+	const allDone = $derived(total > 0 && completed === total);
+
+	const modeOptions = $derived([
+		{ value: 'play', label: isEnglish ? '🎯 One by One' : '🎯 Satu per Satu' },
+		{ value: 'all', label: isEnglish ? '📋 Show All' : '📋 Tampilkan Semua' }
+	]);
+
+	function getCount(id: number) {
+		return counts[id] ?? 0;
+	}
+
+	function handleIncrement(id: number, target: number) {
+		const cur = counts[id] ?? 0;
+		if (cur < target) {
+			counts = { ...counts, [id]: cur + 1 };
+		}
+	}
+
+	function handleReset(id: number) {
+		counts = { ...counts, [id]: 0 };
+	}
+
+	function handleResetAll() {
+		counts = {};
+		currentPlayIndex = 0;
+		slideDir = 1;
+	}
+
+	function goNext() {
+		if (currentPlayIndex < total - 1) {
+			slideDir = 1;
+			currentPlayIndex++;
+		}
+	}
+
+	function goPrev() {
+		if (currentPlayIndex > 0) {
+			slideDir = -1;
+			currentPlayIndex--;
+		}
+	}
+
+	function isItemDone(id: number, count: number, href?: string) {
+		if (href) return false; // link items never "done" for progress dots
+		return (counts[id] ?? 0) >= count;
+	}
 </script>
 
 <svelte:head>
@@ -31,30 +84,228 @@
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
+	<Breadcrumb
+		items={[
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
+			{ text: 'Tahlil', href: '/tahlil/' }
+		]}
+	/>
 </div>
 
-<div class="px-4 flex flex-col gap-2">
-	{#each tahlil.data as item (item.id)}
-		<CardShadow>
-			<div class="flex flex-col justify-center gap-4">
-				<span class="font-bold text-left">💠 {item.title}</span>
-				<span class="text-2xl font-arabic text-right">{item.arabic}</span>
+<div class="px-4 flex flex-col gap-4 pb-24">
+	<!-- Progress card -->
+	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
+		<div class="flex items-center justify-between gap-3">
+			<div>
+				<p class="text-sm opacity-70">
+					{isEnglish ? 'Progress' : 'Progress'}
+				</p>
+				<p
+					class="font-bold text-lg tabular-nums {allDone
+						? 'text-green-600 dark:text-green-400'
+						: ''}"
+				>
+					{completed} / {total}
+					{#if allDone}
+						<span class="text-sm font-normal">— {isEnglish ? 'complete!' : 'selesai!'} 🎉</span>
+					{/if}
+				</p>
 			</div>
-			<div class="mt-4 flex justify-between items-center gap-2">
-				<div class="flex items-center gap-2">
-					<Button
-						onClick={() => {
-							toggleBottomSheet(item);
-						}}
-						ariaLabel="Baca Terjemah"
-					>
-						<DocumentTextIcon />
-					</Button>
+			<button
+				type="button"
+				onclick={handleResetAll}
+				class="cursor-pointer rounded-lg px-3 py-2 text-xs font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 transition"
+			>
+				{isEnglish ? 'Reset all' : 'Reset semua'}
+			</button>
+		</div>
+		<div class="w-full bg-primary rounded-full h-2 overflow-hidden">
+			<div
+				class="h-2 rounded-full transition-all duration-500 {allDone
+					? 'bg-green-500'
+					: 'bg-teal-500'}"
+				style="width: {total === 0 ? 0 : (completed / total) * 100}%"
+			></div>
+		</div>
+	</div>
+
+	<!-- Mode tabs (hidden during celebration) -->
+	{#if !allDone}
+		<Tabs
+			options={modeOptions}
+			value={playMode ? 'play' : 'all'}
+			onchange={(v) => {
+				playMode = v === 'play';
+			}}
+		/>
+	{/if}
+
+	<!-- ===== CELEBRATION ===== -->
+	{#if allDone}
+		<div
+			class="flex flex-col items-center gap-6 py-6 text-center"
+			in:fly={{ y: 60, duration: 500, easing: cubicOut }}
+		>
+			<div class="relative w-32 h-32 flex items-center justify-center">
+				<span class="trophy text-7xl select-none">🤲</span>
+			</div>
+			<div class="flex flex-col gap-2">
+				<h2 class="text-3xl font-bold">Alhamdulillah! 🎉</h2>
+				<p class="text-xl font-semibold">
+					{isEnglish ? 'Tahlil Complete!' : 'Tahlil Selesai!'}
+				</p>
+				<p class="text-sm opacity-70 max-w-xs mx-auto">
+					{isEnglish
+						? `You have completed all ${total} tahlil readings`
+						: `Kamu telah menyelesaikan semua ${total} bacaan tahlil`}
+				</p>
+			</div>
+			<div
+				class="bg-green-50 dark:bg-green-950/60 border-2 border-green-200 dark:border-green-800 rounded-2xl px-10 py-5 flex flex-col items-center"
+			>
+				<span class="text-5xl font-bold text-green-600 dark:text-green-400 tabular-nums"
+					>{total}</span
+				>
+				<span class="text-sm text-green-700 dark:text-green-300 mt-1">
+					{isEnglish ? 'Readings completed' : 'Bacaan selesai'}
+				</span>
+			</div>
+			<div class="flex flex-col gap-3 w-full">
+				<button
+					type="button"
+					onclick={handleResetAll}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition"
+				>
+					{isEnglish ? '↺ Start again' : '↺ Mulai lagi'}
+				</button>
+				<button
+					type="button"
+					onclick={() => {
+						playMode = false;
+					}}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition text-sm opacity-70"
+				>
+					{isEnglish ? '📋 Show all readings' : '📋 Tampilkan semua bacaan'}
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== PLAY MODE ===== -->
+	{:else if playMode}
+		<div class="flex flex-col gap-4">
+			<!-- Step indicator -->
+			<div class="flex flex-col items-center gap-2">
+				<p class="text-sm font-semibold opacity-70">
+					{isEnglish
+						? `Reading ${currentPlayIndex + 1} of ${total}`
+						: `Bacaan ke-${currentPlayIndex + 1} dari ${total}`}
+				</p>
+				<div class="flex gap-1.5 items-center justify-center flex-wrap">
+					{#each items as item, i}
+						{@const isDone = isItemDone(item.id, item.count, item.href)}
+						<div
+							class="rounded-full transition-all duration-300 {isDone
+								? 'w-2.5 h-2.5 bg-green-500 dark:bg-green-400'
+								: i === currentPlayIndex
+									? 'w-3.5 h-3.5 bg-teal-500 dark:bg-teal-400 ring-2 ring-teal-300/60 dark:ring-teal-600/60'
+									: 'w-2 h-2 bg-foreground/15'}"
+						></div>
+					{/each}
 				</div>
 			</div>
-		</CardShadow>
-	{/each}
+
+			<!-- Card stack -->
+			<div class="relative" style="padding-bottom: 20px;">
+				{#if currentPlayIndex + 2 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/10"
+						style="bottom: 0; left: 24px; right: 24px; height: 28px; z-index: 1;"
+					></div>
+				{/if}
+				{#if currentPlayIndex + 1 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/15 shadow-sm"
+						style="bottom: 8px; left: 12px; right: 12px; height: 28px; z-index: 2;"
+					></div>
+				{/if}
+				<div class="relative overflow-x-hidden" style="z-index: 3;">
+					{#key currentPlayIndex}
+						<div
+							in:fly={{ x: slideDir * 380, duration: 380, easing: cubicOut }}
+							out:fly={{ x: -slideDir * 380, duration: 280 }}
+						>
+							{#if currentItem}
+								<ReadingCard
+									item={currentItem}
+									count={getCount(currentItem.id)}
+									playMode={true}
+									isLast={currentPlayIndex === total - 1}
+									onIncrement={() => handleIncrement(currentItem.id, currentItem.count)}
+									onReset={() => handleReset(currentItem.id)}
+									onNext={goNext}
+								/>
+							{/if}
+						</div>
+					{/key}
+				</div>
+			</div>
+
+			<!-- Prev / Next navigation -->
+			<div class="flex items-center justify-between">
+				<button
+					type="button"
+					onclick={goPrev}
+					disabled={currentPlayIndex === 0}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					← {isEnglish ? 'Previous' : 'Sebelumnya'}
+				</button>
+				<button
+					type="button"
+					onclick={goNext}
+					disabled={currentPlayIndex >= total - 1}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					{isEnglish ? 'Next' : 'Berikutnya'} →
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== ALL MODE ===== -->
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each items as item (item.id)}
+				<ReadingCard
+					{item}
+					count={getCount(item.id)}
+					onIncrement={() => handleIncrement(item.id, item.count)}
+					onReset={() => handleReset(item.id)}
+				/>
+			{/each}
+		</div>
+	{/if}
+
+	<!-- Source -->
+	<p class="text-xs opacity-40 text-center mt-2">
+		{isEnglish ? 'Source' : 'Sumber'}: {tahlil.basedOn}
+	</p>
 </div>
 
 <SeoText variant="TAHLIL" />
+
+<style>
+	@keyframes float {
+		0%,
+		100% {
+			transform: translateY(0px);
+		}
+		50% {
+			transform: translateY(-8px);
+		}
+	}
+
+	.trophy {
+		animation: float 3s ease-in-out infinite;
+		display: inline-block;
+	}
+</style>

--- a/src/routes/wirid/+page.svelte
+++ b/src/routes/wirid/+page.svelte
@@ -1,12 +1,73 @@
 <script lang="ts">
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
-	import CardShadow from '$lib/CardShadow.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import SeoText from '$lib/SeoText.svelte';
+	import ReadingCard from '$lib/ReadingCard.svelte';
+	import Tabs from '$lib/ui/Tabs.svelte';
 	import { META_DESC_WIRID, META_TITLE_WIRID, TITLE_CONSTANTS } from '$lib/constants';
+	import { LANGUAGE_OPTIONS, languageStore } from '$lib/checkLanguaguage';
 	import { t } from '$lib/translations/store';
-	import Badge from '$lib/ui/Badge.svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import wirid from '../../data/wirid';
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	const items = wirid.data;
+	const total = items.length;
+
+	let playMode = $state(true);
+	let currentPlayIndex = $state(0);
+	let slideDir = $state(1);
+	let counts = $state<Record<number, number>>({});
+
+	const currentItem = $derived(currentPlayIndex < total ? items[currentPlayIndex] : null);
+	const completed = $derived(items.filter((i) => (counts[i.id] ?? 0) >= i.count).length);
+	const allDone = $derived(total > 0 && completed === total);
+
+	const modeOptions = $derived([
+		{ value: 'play', label: isEnglish ? '🎯 One by One' : '🎯 Satu per Satu' },
+		{ value: 'all', label: isEnglish ? '📋 Show All' : '📋 Tampilkan Semua' }
+	]);
+
+	function getCount(id: number) {
+		return counts[id] ?? 0;
+	}
+
+	function handleIncrement(id: number, target: number) {
+		const cur = counts[id] ?? 0;
+		if (cur < target) {
+			counts = { ...counts, [id]: cur + 1 };
+		}
+	}
+
+	function handleReset(id: number) {
+		counts = { ...counts, [id]: 0 };
+	}
+
+	function handleResetAll() {
+		counts = {};
+		currentPlayIndex = 0;
+		slideDir = 1;
+	}
+
+	function goNext() {
+		if (currentPlayIndex < total - 1) {
+			slideDir = 1;
+			currentPlayIndex++;
+		}
+	}
+
+	function goPrev() {
+		if (currentPlayIndex > 0) {
+			slideDir = -1;
+			currentPlayIndex--;
+		}
+	}
+
+	function isItemDone(id: number, count: number) {
+		return getCount(id) >= count;
+	}
 </script>
 
 <svelte:head>
@@ -14,41 +75,232 @@
 </svelte:head>
 
 <div class="flex gap-2 px-4 mb-4">
-	<h1 class="text-3xl font-bold">🧎 Wirid</h1>
+	<h1 class="text-3xl font-bold">🧎 {isEnglish ? 'Wirid After Prayer' : 'Wirid Setelah Sholat'}</h1>
 </div>
 
 <div class="px-4 mb-4">
-	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
+	<Breadcrumb
+		items={[
+			{ text: `🏠 ${$t('navigation.home')}`, href: '/' },
+			{ text: isEnglish ? 'Wirid' : 'Wirid', href: '/wirid/' }
+		]}
+	/>
 </div>
 
-<div class="px-4 flex flex-col gap-2">
-	{#each wirid.data as item (item.id)}
-		<CardShadow>
-			<div class="relative">
-				{#if item.arabic.indexOf('Membaca') >= 0}
-					<div class="absolute bottom-0 right-0">
-						<Badge color="success">
-							{`${item.id}x`}
-						</Badge>
-					</div>
-				{:else}
-					<div class="absolute bottom-0 left-0">
-						<Badge color="success">
-							{`${item.id}x`}
-						</Badge>
-					</div>
-				{/if}
-
-				<div class="flex flex-col items-end justify-center">
-					{#if item.arabic.indexOf('Membaca') >= 0}
-						<span class="font-bold text-xl">{item.arabic}</span>
-					{:else}
-						<span class="text-2xl font-arabic text-right">{item.arabic}</span>
+<div class="px-4 flex flex-col gap-4 pb-24">
+	<!-- Progress card -->
+	<div class="bg-secondary rounded-xl p-4 flex flex-col gap-3">
+		<div class="flex items-center justify-between gap-3">
+			<div>
+				<p class="text-sm opacity-70">
+					{isEnglish ? 'Progress' : 'Progress'}
+				</p>
+				<p
+					class="font-bold text-lg tabular-nums {allDone
+						? 'text-green-600 dark:text-green-400'
+						: ''}"
+				>
+					{completed} / {total}
+					{#if allDone}
+						<span class="text-sm font-normal">— {isEnglish ? 'complete!' : 'selesai!'} 🎉</span>
 					{/if}
+				</p>
+			</div>
+			<button
+				type="button"
+				onclick={handleResetAll}
+				class="cursor-pointer rounded-lg px-3 py-2 text-xs font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 transition"
+			>
+				{isEnglish ? 'Reset all' : 'Reset semua'}
+			</button>
+		</div>
+		<div class="w-full bg-primary rounded-full h-2 overflow-hidden">
+			<div
+				class="h-2 rounded-full transition-all duration-500 {allDone
+					? 'bg-green-500'
+					: 'bg-teal-500'}"
+				style="width: {total === 0 ? 0 : (completed / total) * 100}%"
+			></div>
+		</div>
+	</div>
+
+	<!-- Mode tabs (hidden during celebration) -->
+	{#if !allDone}
+		<Tabs
+			options={modeOptions}
+			value={playMode ? 'play' : 'all'}
+			onchange={(v) => {
+				playMode = v === 'play';
+			}}
+		/>
+	{/if}
+
+	<!-- ===== CELEBRATION ===== -->
+	{#if allDone}
+		<div
+			class="flex flex-col items-center gap-6 py-6 text-center"
+			in:fly={{ y: 60, duration: 500, easing: cubicOut }}
+		>
+			<div class="relative w-32 h-32 flex items-center justify-center">
+				<span class="trophy text-7xl select-none">🤲</span>
+			</div>
+			<div class="flex flex-col gap-2">
+				<h2 class="text-3xl font-bold">Alhamdulillah! 🎉</h2>
+				<p class="text-xl font-semibold">
+					{isEnglish ? 'Wirid Complete!' : 'Wirid Selesai!'}
+				</p>
+				<p class="text-sm opacity-70 max-w-xs mx-auto">
+					{isEnglish
+						? `You have completed all ${total} wirid readings`
+						: `Kamu telah menyelesaikan semua ${total} bacaan wirid`}
+				</p>
+			</div>
+			<div
+				class="bg-green-50 dark:bg-green-950/60 border-2 border-green-200 dark:border-green-800 rounded-2xl px-10 py-5 flex flex-col items-center"
+			>
+				<span class="text-5xl font-bold text-green-600 dark:text-green-400 tabular-nums"
+					>{total}</span
+				>
+				<span class="text-sm text-green-700 dark:text-green-300 mt-1">
+					{isEnglish ? 'Readings completed' : 'Bacaan selesai'}
+				</span>
+			</div>
+			<div class="flex flex-col gap-3 w-full">
+				<button
+					type="button"
+					onclick={handleResetAll}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold bg-primary border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition"
+				>
+					{isEnglish ? '↺ Start again' : '↺ Mulai lagi'}
+				</button>
+				<button
+					type="button"
+					onclick={() => {
+						playMode = false;
+					}}
+					class="w-full cursor-pointer rounded-xl px-4 py-3 font-semibold border-2 border-foreground/20 hover:border-foreground/40 active:scale-[0.98] transition text-sm opacity-70"
+				>
+					{isEnglish ? '📋 Show all readings' : '📋 Tampilkan semua bacaan'}
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== PLAY MODE ===== -->
+	{:else if playMode}
+		<div class="flex flex-col gap-4">
+			<!-- Step indicator -->
+			<div class="flex flex-col items-center gap-2">
+				<p class="text-sm font-semibold opacity-70">
+					{isEnglish
+						? `Reading ${currentPlayIndex + 1} of ${total}`
+						: `Bacaan ke-${currentPlayIndex + 1} dari ${total}`}
+				</p>
+				<div class="flex gap-2 items-center justify-center flex-wrap">
+					{#each items as item, i}
+						{@const isDone = isItemDone(item.id, item.count)}
+						<div
+							class="rounded-full transition-all duration-300 {isDone
+								? 'w-2.5 h-2.5 bg-green-500 dark:bg-green-400'
+								: i === currentPlayIndex
+									? 'w-3.5 h-3.5 bg-teal-500 dark:bg-teal-400 ring-2 ring-teal-300/60 dark:ring-teal-600/60'
+									: 'w-2.5 h-2.5 bg-foreground/15'}"
+						></div>
+					{/each}
 				</div>
 			</div>
-		</CardShadow>
-	{/each}
+
+			<!-- Card stack -->
+			<div class="relative" style="padding-bottom: 20px;">
+				{#if currentPlayIndex + 2 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/10"
+						style="bottom: 0; left: 24px; right: 24px; height: 28px; z-index: 1;"
+					></div>
+				{/if}
+				{#if currentPlayIndex + 1 < total}
+					<div
+						class="absolute rounded-xl bg-secondary border border-foreground/15 shadow-sm"
+						style="bottom: 8px; left: 12px; right: 12px; height: 28px; z-index: 2;"
+					></div>
+				{/if}
+				<div class="relative overflow-x-hidden" style="z-index: 3;">
+					{#key currentPlayIndex}
+						<div
+							in:fly={{ x: slideDir * 380, duration: 380, easing: cubicOut }}
+							out:fly={{ x: -slideDir * 380, duration: 280 }}
+						>
+							{#if currentItem}
+								<ReadingCard
+									item={currentItem}
+									count={getCount(currentItem.id)}
+									playMode={true}
+									isLast={currentPlayIndex === total - 1}
+									onIncrement={() => handleIncrement(currentItem.id, currentItem.count)}
+									onReset={() => handleReset(currentItem.id)}
+									onNext={goNext}
+								/>
+							{/if}
+						</div>
+					{/key}
+				</div>
+			</div>
+
+			<!-- Prev / Next navigation -->
+			<div class="flex items-center justify-between">
+				<button
+					type="button"
+					onclick={goPrev}
+					disabled={currentPlayIndex === 0}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					← {isEnglish ? 'Previous' : 'Sebelumnya'}
+				</button>
+				<button
+					type="button"
+					onclick={goNext}
+					disabled={currentPlayIndex >= total - 1}
+					class="rounded-lg px-3 py-2 text-xs font-semibold border border-foreground/15 hover:border-foreground/30 disabled:opacity-25 disabled:cursor-not-allowed cursor-pointer transition"
+				>
+					{isEnglish ? 'Next' : 'Berikutnya'} →
+				</button>
+			</div>
+		</div>
+
+		<!-- ===== ALL MODE ===== -->
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each items as item (item.id)}
+				<ReadingCard
+					{item}
+					count={getCount(item.id)}
+					onIncrement={() => handleIncrement(item.id, item.count)}
+					onReset={() => handleReset(item.id)}
+				/>
+			{/each}
+		</div>
+	{/if}
+
+	<!-- Source -->
+	<p class="text-xs opacity-40 text-center mt-2">
+		{isEnglish ? 'Source' : 'Sumber'}: {wirid.basedOn}
+	</p>
 </div>
 
 <SeoText variant="WIRID" />
+
+<style>
+	@keyframes float {
+		0%,
+		100% {
+			transform: translateY(0px);
+		}
+		50% {
+			transform: translateY(-8px);
+		}
+	}
+
+	.trophy {
+		animation: float 3s ease-in-out infinite;
+		display: inline-block;
+	}
+</style>


### PR DESCRIPTION
- Rewrote wirid.ts with 20 NU-sourced items including actual Arabic text
  for all items (Al-Ikhlas, Al-Falaq, An-Nas, Al-Fatihah, Ayat Kursi, etc.)
- Rewrote tahlil.ts with 14 items following NU Majmu' Syarif sequence,
  including Surah Yasin as a link card (href: '/36')
- New generic ReadingCard.svelte component with play/all modes, counter,
  teal color scheme, and link card support for surah references
- Redesigned wirid and tahlil pages: play mode by default, card stack
  animation, progress bar, dot indicators, celebration screen
- Used U+2019 (RIGHT SINGLE QUOTATION MARK) throughout Latin
  transliterations to avoid TypeScript string literal termination

https://claude.ai/code/session_01TfQJb8JkGZd7PzkjUyvq1L