### PR TITLE
fix(ci): use GITHUB_TOKEN directly in rotate-ayah-seed workflow

### DIFF
--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: rotate-ayah-seed
@@ -23,7 +24,7 @@ jobs:
   rotate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.repository == 'mazipan/baca-quran.id' || github.repository == 'mazipan-quran-offline/baca-quran.id'
+    if: github.repository == 'mazipan/baca-quran.id'
 
     steps:
       - name: Checkout
@@ -74,14 +75,23 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `year=${year}\n`);
           EOF
 
-      - name: Commit and push
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/ayah-seed-${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }}"
+          git checkout -b "$BRANCH"
           git add src/data/ayah-of-the-day-seeds.json
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
           fi
           git commit -m "chore(ayah-of-the-day): seed for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }} (${{ steps.rotate.outputs.action }})"
-          git push origin HEAD:${{ github.ref_name }}
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(ayah-of-the-day): seed for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }} (${{ steps.rotate.outputs.action }})" \
+            --body "Automated monthly seed rotation for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }}." \
+            --label "automerge" \
+            --base "${{ github.ref_name }}"

--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: true
-          token: ${{ secrets.PERSONAL_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rotate seed
         id: rotate

--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Open PR
         if: steps.push.outputs.changed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BRANCH: ${{ steps.push.outputs.branch }}
           YEAR: ${{ steps.rotate.outputs.year }}

--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -75,14 +75,12 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `year=${year}\n`);
           EOF
 
-      - name: Open PR
+      - name: Commit and push
+        id: push
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YEAR: ${{ steps.rotate.outputs.year }}
           MONTH: ${{ steps.rotate.outputs.month }}
           ACTION: ${{ steps.rotate.outputs.action }}
-          BASE_BRANCH: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -91,29 +89,35 @@ jobs:
           git add src/data/ayah-of-the-day-seeds.json
           if git diff --cached --quiet; then
             echo "No changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore(ayah-of-the-day): seed for ${YEAR}-${MONTH} (${ACTION})"
           git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
-          PR_PAYLOAD=$(jq -n \
-            --arg title "chore(ayah-of-the-day): seed for ${YEAR}-${MONTH} (${ACTION})" \
-            --arg body "Automated monthly seed rotation for ${YEAR}-${MONTH}." \
-            --arg head "$BRANCH" \
-            --arg base "$BASE_BRANCH" \
-            '{title: $title, body: $body, head: $head, base: $base}')
-
-          PR_NUMBER=$(curl -s -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/pulls" \
-            -d "$PR_PAYLOAD" \
-            | jq -r '.number')
-
-          curl -s -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/labels" \
-            -d '{"labels":["automerge"]}'
+      - name: Open PR
+        if: steps.push.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ steps.push.outputs.branch }}
+          YEAR: ${{ steps.rotate.outputs.year }}
+          MONTH: ${{ steps.rotate.outputs.month }}
+          ACTION: ${{ steps.rotate.outputs.action }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore(ayah-of-the-day): seed for ${process.env.YEAR}-${process.env.MONTH} (${process.env.ACTION})`,
+              body: `Automated monthly seed rotation for ${process.env.YEAR}-${process.env.MONTH}.`,
+              head: process.env.BRANCH,
+              base: context.ref.replace('refs/heads/', ''),
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['automerge'],
+            });

--- a/.github/workflows/rotate-ayah-seed.yml
+++ b/.github/workflows/rotate-ayah-seed.yml
@@ -78,20 +78,42 @@ jobs:
       - name: Open PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          YEAR: ${{ steps.rotate.outputs.year }}
+          MONTH: ${{ steps.rotate.outputs.month }}
+          ACTION: ${{ steps.rotate.outputs.action }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="chore/ayah-seed-${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }}"
+          BRANCH="chore/ayah-seed-${YEAR}-${MONTH}"
           git checkout -b "$BRANCH"
           git add src/data/ayah-of-the-day-seeds.json
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
           fi
-          git commit -m "chore(ayah-of-the-day): seed for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }} (${{ steps.rotate.outputs.action }})"
+          git commit -m "chore(ayah-of-the-day): seed for ${YEAR}-${MONTH} (${ACTION})"
           git push origin "$BRANCH"
-          gh pr create \
-            --title "chore(ayah-of-the-day): seed for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }} (${{ steps.rotate.outputs.action }})" \
-            --body "Automated monthly seed rotation for ${{ steps.rotate.outputs.year }}-${{ steps.rotate.outputs.month }}." \
-            --label "automerge" \
-            --base "${{ github.ref_name }}"
+
+          PR_PAYLOAD=$(jq -n \
+            --arg title "chore(ayah-of-the-day): seed for ${YEAR}-${MONTH} (${ACTION})" \
+            --arg body "Automated monthly seed rotation for ${YEAR}-${MONTH}." \
+            --arg head "$BRANCH" \
+            --arg base "$BASE_BRANCH" \
+            '{title: $title, body: $body, head: $head, base: $base}')
+
+          PR_NUMBER=$(curl -s -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/pulls" \
+            -d "$PR_PAYLOAD" \
+            | jq -r '.number')
+
+          curl -s -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            -d '{"labels":["automerge"]}'

--- a/.github/workflows/switch-ayah-theme.yml
+++ b/.github/workflows/switch-ayah-theme.yml
@@ -62,10 +62,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THEME_INPUT: ${{ inputs.theme }}
           ACTOR: ${{ github.actor }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="chore/ayah-theme-${THEME_INPUT}-${{ github.run_id }}"
+          BRANCH="chore/ayah-theme-${THEME_INPUT}-${RUN_ID}"
           git checkout -b "$BRANCH"
           git add src/data/ayah-of-the-day-config.json
           if git diff --cached --quiet; then
@@ -74,8 +77,25 @@ jobs:
           fi
           git commit -m "chore(ayah-of-the-day): switch theme to ${THEME_INPUT} by ${ACTOR}"
           git push origin "$BRANCH"
-          gh pr create \
-            --title "chore(ayah-of-the-day): switch theme to ${THEME_INPUT}" \
-            --body "Automated theme switch to \`${THEME_INPUT}\` triggered by @${ACTOR}." \
-            --label "automerge" \
-            --base "${{ github.ref_name }}"
+
+          PR_PAYLOAD=$(jq -n \
+            --arg title "chore(ayah-of-the-day): switch theme to ${THEME_INPUT}" \
+            --arg body "Automated theme switch to \`${THEME_INPUT}\` triggered by @${ACTOR}." \
+            --arg head "$BRANCH" \
+            --arg base "$BASE_BRANCH" \
+            '{title: $title, body: $body, head: $head, base: $base}')
+
+          PR_NUMBER=$(curl -s -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/pulls" \
+            -d "$PR_PAYLOAD" \
+            | jq -r '.number')
+
+          curl -s -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            -d '{"labels":["automerge"]}'

--- a/.github/workflows/switch-ayah-theme.yml
+++ b/.github/workflows/switch-ayah-theme.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Open PR
         if: steps.push.outputs.changed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BRANCH: ${{ steps.push.outputs.branch }}
           THEME_INPUT: ${{ inputs.theme }}

--- a/.github/workflows/switch-ayah-theme.yml
+++ b/.github/workflows/switch-ayah-theme.yml
@@ -57,13 +57,11 @@ jobs:
           fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
           EOF
 
-      - name: Open PR
+      - name: Commit and push
+        id: push
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THEME_INPUT: ${{ inputs.theme }}
           ACTOR: ${{ github.actor }}
-          BASE_BRANCH: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
           git config user.name "github-actions[bot]"
@@ -73,29 +71,34 @@ jobs:
           git add src/data/ayah-of-the-day-config.json
           if git diff --cached --quiet; then
             echo "No changes to commit (already on requested theme)."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore(ayah-of-the-day): switch theme to ${THEME_INPUT} by ${ACTOR}"
           git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
-          PR_PAYLOAD=$(jq -n \
-            --arg title "chore(ayah-of-the-day): switch theme to ${THEME_INPUT}" \
-            --arg body "Automated theme switch to \`${THEME_INPUT}\` triggered by @${ACTOR}." \
-            --arg head "$BRANCH" \
-            --arg base "$BASE_BRANCH" \
-            '{title: $title, body: $body, head: $head, base: $base}')
-
-          PR_NUMBER=$(curl -s -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/pulls" \
-            -d "$PR_PAYLOAD" \
-            | jq -r '.number')
-
-          curl -s -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/labels" \
-            -d '{"labels":["automerge"]}'
+      - name: Open PR
+        if: steps.push.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ steps.push.outputs.branch }}
+          THEME_INPUT: ${{ inputs.theme }}
+          ACTOR: ${{ github.actor }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore(ayah-of-the-day): switch theme to ${process.env.THEME_INPUT}`,
+              body: `Automated theme switch to \`${process.env.THEME_INPUT}\` triggered by @${process.env.ACTOR}.`,
+              head: process.env.BRANCH,
+              base: context.ref.replace('refs/heads/', ''),
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['automerge'],
+            });

--- a/.github/workflows/switch-ayah-theme.yml
+++ b/.github/workflows/switch-ayah-theme.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: switch-ayah-theme
@@ -23,14 +24,14 @@ jobs:
   switch:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.repository == 'mazipan/baca-quran.id' || github.repository == 'mazipan-quran-offline/baca-quran.id'
+    if: github.repository == 'mazipan/baca-quran.id'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: true
-          token: ${{ secrets.PERSONAL_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update theme override
         env:
@@ -56,17 +57,25 @@ jobs:
           fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
           EOF
 
-      - name: Commit and push
+      - name: Open PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THEME_INPUT: ${{ inputs.theme }}
           ACTOR: ${{ github.actor }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="chore/ayah-theme-${THEME_INPUT}-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
           git add src/data/ayah-of-the-day-config.json
           if git diff --cached --quiet; then
             echo "No changes to commit (already on requested theme)."
             exit 0
           fi
           git commit -m "chore(ayah-of-the-day): switch theme to ${THEME_INPUT} by ${ACTOR}"
-          git push origin HEAD:${{ github.ref_name }}
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(ayah-of-the-day): switch theme to ${THEME_INPUT}" \
+            --body "Automated theme switch to \`${THEME_INPUT}\` triggered by @${ACTOR}." \
+            --label "automerge" \
+            --base "${{ github.ref_name }}"


### PR DESCRIPTION
PERSONAL_TOKEN being expired/invalid caused the checkout to fail because
the || fallback returns it (truthy non-empty string) instead of falling
back to GITHUB_TOKEN. The workflow only needs contents: write which
GITHUB_TOKEN provides.