### PR TITLE
fix: surah autoplay bugs — dialog update, verse switching, scroll, and defaults

### DIFF
--- a/src/lib/VerseAudioPlayer.svelte
+++ b/src/lib/VerseAudioPlayer.svelte
@@ -26,13 +26,16 @@
 	function play({ surah, verse, totalAyah }: CurrentTrackParam) {
 		if (audioRef) {
 			currentTrack.set({ verse, surah, totalAyah });
+			currentTime = 0;
+			totalTime = 0;
+			percent = 0;
 			const src = getAudioFromEveryAyah($settingAudio, surah, verse);
 			const currentSrc = audioRef.getAttribute('src');
 			if (src !== currentSrc) {
 				audioRef.setAttribute('src', src);
 			}
 			audioRef.load();
-			audioRef.play();
+			audioRef.play().catch(() => {});
 			isPlayingAudio.set(true);
 			isShowingAudioPlayer.set(true);
 			reachingEndOfSurah = false;
@@ -60,7 +63,15 @@
 	function updateAudioTimeline() {
 		if (audioRef) {
 			currentTime = audioRef.currentTime;
-			percent = (currentTime / totalTime) * 100;
+			percent = totalTime > 0 ? (currentTime / totalTime) * 100 : 0;
+		}
+	}
+
+	function handleProgressClick(e: MouseEvent) {
+		if (audioRef && totalTime > 0) {
+			const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+			const newTime = ((e.clientX - rect.left) / rect.width) * totalTime;
+			audioRef.currentTime = Math.max(0, Math.min(newTime, totalTime));
 		}
 	}
 
@@ -162,8 +173,26 @@
 				<span>{formatAudioTime(totalTime)} </span>
 			</div>
 
-			<div class="w-full bg-primary rounded-full h-1.5">
-				<div class="bg-lime-400 h-1.5 rounded-full" style={`width: ${percent}%`}></div>
+			<div
+				class="w-full bg-primary rounded-full h-3 cursor-pointer flex items-center"
+				role="slider"
+				aria-label="Audio progress"
+				aria-valuemin={0}
+				aria-valuemax={totalTime}
+				aria-valuenow={currentTime}
+				tabindex="0"
+				onclick={handleProgressClick}
+				onkeydown={(e) => {
+					if (!audioRef || totalTime <= 0) return;
+					if (e.key === 'ArrowRight')
+						audioRef.currentTime = Math.min(audioRef.currentTime + 5, totalTime);
+					if (e.key === 'ArrowLeft') audioRef.currentTime = Math.max(audioRef.currentTime - 5, 0);
+				}}
+			>
+				<div
+					class="bg-lime-400 h-1.5 rounded-full pointer-events-none"
+					style={`width: ${percent}%`}
+				></div>
 			</div>
 
 			<div class="text-sm mt-2 flex justify-between items-center">

--- a/src/lib/VerseAudioPlayer.svelte
+++ b/src/lib/VerseAudioPlayer.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import { onMount } from 'svelte';
 	import {
 		settingAudio,
@@ -27,21 +25,17 @@
 
 	function play({ surah, verse, totalAyah }: CurrentTrackParam) {
 		if (audioRef) {
-			currentTrack.set({
-				verse,
-				surah,
-				totalAyah
-			});
+			currentTrack.set({ verse, surah, totalAyah });
 			const src = getAudioFromEveryAyah($settingAudio, surah, verse);
 			const currentSrc = audioRef.getAttribute('src');
 			if (src !== currentSrc) {
-				audioRef.setAttribute('src', getAudioFromEveryAyah($settingAudio, surah, verse));
+				audioRef.setAttribute('src', src);
 			}
-
 			audioRef.load();
 			audioRef.play();
 			isPlayingAudio.set(true);
 			isShowingAudioPlayer.set(true);
+			reachingEndOfSurah = false;
 		}
 	}
 
@@ -82,12 +76,20 @@
 				if (!endOfSurah) {
 					const nextVerse = +$currentTrack.verse + 1;
 					const nextSurah = +$currentTrack.surah;
-
-					play({
+					const nextTrack = {
 						surah: `${nextSurah}`,
 						verse: `${nextVerse}`,
 						totalAyah: +$currentTrack.totalAyah
-					});
+					};
+					currentTrack.set(nextTrack);
+					play(nextTrack);
+
+					setTimeout(() => {
+						const el = document.getElementById(`ayat-${nextVerse}`);
+						if (el) {
+							el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+						}
+					}, 100);
 				}
 			}
 		}
@@ -101,30 +103,29 @@
 		}
 	}
 
+	function closePlayer() {
+		pause();
+		currentTrack.set({ surah: '', verse: '', totalAyah: 0 });
+		isShowingAudioPlayer.set(false);
+	}
+
 	function attachListeners() {
 		if (audioRef) {
 			audioRef.addEventListener('timeupdate', updateAudioTimeline);
 			audioRef.addEventListener('loadedmetadata', () => {
 				totalTime = audioRef?.duration ?? 0;
 			});
-
 			audioRef.addEventListener('ended', handleEndPlaying);
-			window.addEventListener('paused', () => {
+
+			window.addEventListener('audio-stop', () => {
 				pause();
+			});
+
+			window.addEventListener('audio-play', (e: Event) => {
+				play((e as CustomEvent<CurrentTrackParam>).detail);
 			});
 		}
 	}
-
-	function closePlayer() {
-		pause();
-		isShowingAudioPlayer.set(false);
-	}
-
-	run(() => {
-		if ($isShowingAudioPlayer) {
-			play($currentTrack);
-		}
-	});
 
 	onMount(() => {
 		attachListeners();

--- a/src/lib/VerseAudioPlayerTrigger.svelte
+++ b/src/lib/VerseAudioPlayerTrigger.svelte
@@ -14,22 +14,28 @@
 
 	let { totalAyah, numberVerse, numberSurah, source }: Props = $props();
 
+	const isThisVerseActive = $derived(
+		$isShowingAudioPlayer &&
+			$currentTrack.surah === numberSurah &&
+			$currentTrack.verse === numberVerse
+	);
+
 	const handleOpenClosePlayer = ({ surah, verse, totalAyah }: CurrentTrackParam) => {
-		if ($isShowingAudioPlayer) {
-			currentTrack.set({
-				surah: '',
-				verse: '',
-				totalAyah: 0
-			});
-			window.dispatchEvent(new CustomEvent('paused'));
+		const isSameVerse =
+			$isShowingAudioPlayer && $currentTrack.surah === surah && $currentTrack.verse === verse;
+
+		if (isSameVerse) {
+			currentTrack.set({ surah: '', verse: '', totalAyah: 0 });
+			window.dispatchEvent(new CustomEvent('audio-stop'));
 			isShowingAudioPlayer.set(false);
 		} else {
-			currentTrack.set({
-				surah,
-				verse,
-				totalAyah
-			});
+			currentTrack.set({ surah, verse, totalAyah });
 			isShowingAudioPlayer.set(true);
+			window.dispatchEvent(
+				new CustomEvent<CurrentTrackParam>('audio-play', {
+					detail: { surah, verse, totalAyah }
+				})
+			);
 		}
 	};
 </script>
@@ -43,9 +49,9 @@
 			totalAyah: totalAyah
 		});
 	}}
-	ariaLabel={`${$isShowingAudioPlayer ? 'Stop' : 'Play'}`}
+	ariaLabel={`${isThisVerseActive ? 'Stop' : 'Play'}`}
 >
-	{#if $isShowingAudioPlayer}
+	{#if isThisVerseActive}
 		<SpeakerXMarkIcon />
 	{:else}
 		<PlayIcon />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -56,7 +56,7 @@
 				settingTranslation.set(!!(storageTranslation && storageTranslation === 'y'));
 
 				const storageAutoNext = localStorage.getItem(CONSTANTS.STORAGE_KEY.AUTO_NEXT);
-				settingAutoNext.set(!!(storageAutoNext && storageAutoNext === 'y'));
+				settingAutoNext.set(storageAutoNext === null ? true : storageAutoNext === 'y');
 
 				const storageAudio = localStorage.getItem(CONSTANTS.STORAGE_KEY.AUDIO);
 				if (storageAudio) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ export const settingTranslation = writable(false);
 export const settingTafsir = writable(false);
 export const settingMuqadimah = writable(false);
 export const settingAudio = writable<ReciterKey>('1');
-export const settingAutoNext = writable(false);
+export const settingAutoNext = writable(true);
 
 export type LocationParam = {
 	lt: number;


### PR DESCRIPTION
- Remove reactive run() block from VerseAudioPlayer; use explicit audio-play/
  audio-stop custom events instead. This eliminates the double-play loop where
  autoplay's currentTrack.set() re-triggered the effect and could reopen a
  closed player.

- Fix VerseAudioPlayerTrigger to compare the clicked verse against currentTrack,
  so clicking a different verse while playing switches tracks (instead of always
  closing), and the active stop-icon appears only on the currently playing verse.

- closePlayer() now clears currentTrack so state is fully reset on close.

- handleEndPlaying() sets currentTrack before calling play() and scrolls the
  page to the newly active verse card (id="ayat-N") on autoplay advance.

- settingAutoNext defaults to true; layout hydration also defaults to true when
  no localStorage value exists yet.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016ghybWu61pNQbqsEos8gX1