### PR TITLE
feat: add mood-based verse picker at /suasana-hati (#414)

### DIFF
--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -19,5 +19,6 @@ export const staticUrls = [
 	'/tasbih',
 	'/wirid',
 	'/pencatat-ibadah',
-	'/pencatat-ibadah/rekap'
+	'/pencatat-ibadah/rekap',
+	'/suasana-hati'
 ];

--- a/src/data/mood-verses.ts
+++ b/src/data/mood-verses.ts
@@ -1,0 +1,321 @@
+export type MoodId =
+	'cemas' | 'bersyukur' | 'sedih' | 'takut' | 'marah' | 'lemah-iman' | 'tobat' | 'bahagia';
+
+export interface MoodVerse {
+	s: number;
+	v: number;
+	reasonId: string;
+	reasonEn: string;
+}
+
+export interface Mood {
+	id: MoodId;
+	emoji: string;
+	labelKey: string;
+	verses: MoodVerse[];
+}
+
+export const MOODS: readonly Mood[] = [
+	{
+		id: 'cemas',
+		emoji: '😟',
+		labelKey: 'mood.moods.cemas',
+		verses: [
+			{
+				s: 13,
+				v: 28,
+				reasonId: 'Hanya dengan mengingat Allah hati menjadi tenang.',
+				reasonEn: 'In the remembrance of Allah do hearts find rest.'
+			},
+			{
+				s: 94,
+				v: 5,
+				reasonId: 'Bersama setiap kesulitan pasti ada kemudahan.',
+				reasonEn: 'With every hardship comes ease.'
+			},
+			{
+				s: 94,
+				v: 6,
+				reasonId: 'Allah menegaskan: setelah kesulitan ada kemudahan.',
+				reasonEn: 'Allah affirms: after hardship will be ease.'
+			},
+			{
+				s: 2,
+				v: 286,
+				reasonId: 'Allah tidak membebani seseorang melebihi kesanggupannya.',
+				reasonEn: 'Allah does not burden a soul beyond what it can bear.'
+			},
+			{
+				s: 65,
+				v: 3,
+				reasonId: 'Barang siapa bertawakkal kepada Allah, Dia mencukupinya.',
+				reasonEn: 'Whoever relies upon Allah, He will be sufficient for him.'
+			}
+		]
+	},
+	{
+		id: 'bersyukur',
+		emoji: '🙏',
+		labelKey: 'mood.moods.bersyukur',
+		verses: [
+			{
+				s: 14,
+				v: 7,
+				reasonId: 'Jika bersyukur, Allah akan menambah nikmat bagimu.',
+				reasonEn: 'If you are grateful, I will surely increase you in favor.'
+			},
+			{
+				s: 55,
+				v: 13,
+				reasonId: 'Nikmat Tuhanmu yang manakah yang kamu dustakan?',
+				reasonEn: 'Which of the favors of your Lord will you deny?'
+			},
+			{
+				s: 1,
+				v: 2,
+				reasonId: 'Segala puji bagi Allah, Rabb semesta alam.',
+				reasonEn: 'All praise is due to Allah, Lord of all the worlds.'
+			},
+			{
+				s: 2,
+				v: 152,
+				reasonId: 'Ingatlah Allah, Dia akan mengingatmu. Bersyukurlah dan jangan kufur.',
+				reasonEn: 'Remember Me and I will remember you. Be grateful and do not deny Me.'
+			},
+			{
+				s: 31,
+				v: 12,
+				reasonId: 'Barang siapa bersyukur, sesungguhnya bersyukur untuk dirinya sendiri.',
+				reasonEn: 'Whoever is grateful, his gratitude is only for the benefit of himself.'
+			}
+		]
+	},
+	{
+		id: 'sedih',
+		emoji: '😢',
+		labelKey: 'mood.moods.sedih',
+		verses: [
+			{
+				s: 94,
+				v: 5,
+				reasonId: 'Setelah setiap kesulitan, ada kemudahan yang menanti.',
+				reasonEn: 'After every difficulty there is relief waiting.'
+			},
+			{
+				s: 3,
+				v: 139,
+				reasonId: 'Janganlah bersedih hati; kamulah yang paling tinggi derajatnya jika beriman.',
+				reasonEn: 'Do not weaken and do not grieve; you will be superior if you are true believers.'
+			},
+			{
+				s: 39,
+				v: 53,
+				reasonId: 'Jangan berputus asa dari rahmat Allah; Dia mengampuni semua dosa.',
+				reasonEn: 'Do not despair of the mercy of Allah; He forgives all sins.'
+			},
+			{
+				s: 12,
+				v: 87,
+				reasonId: 'Hanya orang-orang kafir yang berputus asa dari rahmat Allah.',
+				reasonEn: 'No one despairs of the mercy of Allah except the disbelieving people.'
+			},
+			{
+				s: 2,
+				v: 286,
+				reasonId: 'Allah tidak membebani seseorang melebihi kemampuannya.',
+				reasonEn: 'Allah does not burden a soul beyond what it can bear.'
+			}
+		]
+	},
+	{
+		id: 'takut',
+		emoji: '😨',
+		labelKey: 'mood.moods.takut',
+		verses: [
+			{
+				s: 2,
+				v: 255,
+				reasonId: 'Ayat Kursi — perlindungan dan keagungan Allah yang sempurna.',
+				reasonEn: 'The Throne Verse — the perfect protection and majesty of Allah.'
+			},
+			{
+				s: 9,
+				v: 51,
+				reasonId:
+					'Tidak ada yang menimpa kami kecuali apa yang Allah tetapkan; Dia pelindung kami.',
+				reasonEn: 'Nothing will befall us except what Allah has decreed; He is our protector.'
+			},
+			{
+				s: 65,
+				v: 3,
+				reasonId: 'Barang siapa bertawakkal kepada Allah, Dia mencukupinya.',
+				reasonEn: 'Whoever relies upon Allah, He will be sufficient for him.'
+			},
+			{
+				s: 3,
+				v: 173,
+				reasonId: 'Cukuplah Allah sebagai pelindung dan sebaik-baik tempat bersandar.',
+				reasonEn: 'Allah is sufficient for us, and He is the best disposer of affairs.'
+			},
+			{
+				s: 67,
+				v: 13,
+				reasonId: 'Allah mengetahui segala sesuatu, termasuk apa yang kamu sembunyikan.',
+				reasonEn: 'Whether you conceal your speech or reveal it, He knows what is in the breasts.'
+			}
+		]
+	},
+	{
+		id: 'marah',
+		emoji: '😡',
+		labelKey: 'mood.moods.marah',
+		verses: [
+			{
+				s: 3,
+				v: 134,
+				reasonId: 'Orang beriman menahan amarah dan memaafkan orang lain.',
+				reasonEn: 'The believers restrain anger and pardon people.'
+			},
+			{
+				s: 41,
+				v: 34,
+				reasonId: 'Tolaklah kejahatan dengan cara yang lebih baik.',
+				reasonEn: 'Repel evil with what is better.'
+			},
+			{
+				s: 7,
+				v: 199,
+				reasonId: 'Tunjukkanlah sikap pemaaf dan jauhi orang-orang yang bodoh.',
+				reasonEn: 'Show forgiveness, enjoin what is good, and turn away from the ignorant.'
+			},
+			{
+				s: 42,
+				v: 37,
+				reasonId: 'Mereka yang apabila ditimpa amarah, mereka memaafkan.',
+				reasonEn: 'Those who, when anger strikes them, forgive.'
+			},
+			{
+				s: 25,
+				v: 63,
+				reasonId:
+					'Hamba Allah yang sejati berjalan dengan rendah hati dan menjawab kebodohan dengan salam.',
+				reasonEn:
+					'The servants of the Most Merciful walk humbly and respond to ignorance with peace.'
+			}
+		]
+	},
+	{
+		id: 'lemah-iman',
+		emoji: '🌑',
+		labelKey: 'mood.moods.lemah_iman',
+		verses: [
+			{
+				s: 8,
+				v: 2,
+				reasonId: 'Orang beriman sejati hatinya bergetar ketika disebut nama Allah.',
+				reasonEn: 'True believers are those whose hearts tremble at the mention of Allah.'
+			},
+			{
+				s: 57,
+				v: 28,
+				reasonId: 'Bertakwalah kepada Allah dan percayalah pada Rasul-Nya.',
+				reasonEn: 'Fear Allah and believe in His Messenger.'
+			},
+			{
+				s: 49,
+				v: 15,
+				reasonId: 'Orang beriman sejati tidak ragu dan berjihad dengan harta dan jiwa.',
+				reasonEn: 'True believers do not doubt and strive with their wealth and lives.'
+			},
+			{
+				s: 2,
+				v: 2,
+				reasonId: "Al-Qur'an adalah petunjuk bagi orang-orang yang bertakwa.",
+				reasonEn: 'The Quran is guidance for those who fear Allah.'
+			},
+			{
+				s: 9,
+				v: 128,
+				reasonId: 'Rasul sangat peduli dan penuh kasih sayang kepada orang-orang beriman.',
+				reasonEn:
+					'The Messenger is deeply concerned for you and compassionate toward the believers.'
+			}
+		]
+	},
+	{
+		id: 'tobat',
+		emoji: '💧',
+		labelKey: 'mood.moods.tobat',
+		verses: [
+			{
+				s: 39,
+				v: 53,
+				reasonId: 'Jangan berputus asa dari rahmat Allah; Dia mengampuni semua dosa.',
+				reasonEn: "Do not despair of Allah's mercy; He forgives all sins."
+			},
+			{
+				s: 2,
+				v: 222,
+				reasonId: 'Allah mencintai orang-orang yang bertaubat dan yang menyucikan diri.',
+				reasonEn: 'Allah loves those who repent and loves those who purify themselves.'
+			},
+			{
+				s: 4,
+				v: 110,
+				reasonId:
+					'Barang siapa berbuat dosa lalu memohon ampunan Allah, niscaya Allah Maha Pengampun.',
+				reasonEn:
+					'Whoever does evil but then seeks forgiveness from Allah will find Allah forgiving and merciful.'
+			},
+			{
+				s: 9,
+				v: 104,
+				reasonId: 'Allah-lah yang menerima taubat dari hamba-hamba-Nya.',
+				reasonEn: 'It is Allah who accepts repentance from His servants.'
+			},
+			{
+				s: 66,
+				v: 8,
+				reasonId: 'Bertaubatlah kepada Allah dengan taubat yang sungguh-sungguh.',
+				reasonEn: 'Repent to Allah with sincere repentance.'
+			}
+		]
+	},
+	{
+		id: 'bahagia',
+		emoji: '🌟',
+		labelKey: 'mood.moods.bahagia',
+		verses: [
+			{
+				s: 13,
+				v: 28,
+				reasonId: 'Hanya dengan mengingat Allah hati menjadi tenteram.',
+				reasonEn: 'In the remembrance of Allah do hearts find rest.'
+			},
+			{
+				s: 16,
+				v: 97,
+				reasonId: 'Barang siapa beramal saleh, Allah akan memberikan kehidupan yang baik.',
+				reasonEn: 'Whoever does righteousness, Allah will grant them a good life.'
+			},
+			{
+				s: 55,
+				v: 60,
+				reasonId: 'Tidak ada balasan kebaikan kecuali kebaikan pula.',
+				reasonEn: 'Is there any reward for good other than good?'
+			},
+			{
+				s: 98,
+				v: 8,
+				reasonId: 'Balasan orang beriman di sisi Allah adalah surga yang penuh kenikmatan.',
+				reasonEn: 'Their reward with Allah is gardens of Eden with rivers flowing beneath.'
+			},
+			{
+				s: 3,
+				v: 185,
+				reasonId: 'Keberhasilan sejati adalah dijauhkan dari neraka dan dimasukkan ke surga.',
+				reasonEn: 'True success is to be kept away from the Fire and admitted into Paradise.'
+			}
+		]
+	}
+];

--- a/src/lib/DrawerMenus.svelte
+++ b/src/lib/DrawerMenus.svelte
@@ -8,6 +8,7 @@
 	import DocumentTextIcon from './icons/DocumentTextIcon.svelte';
 	import GalleryIcon from './icons/GalleryIcon.svelte';
 	import SwatchIcon from './icons/SwatchIcon.svelte';
+	import HeartIcon from './icons/HeartIcon.svelte';
 </script>
 
 <ul class="mt-2 flex flex-col gap-2">
@@ -80,6 +81,16 @@
 		>
 			<SwatchIcon />
 			{$t('navigation.designSystem')}
+		</a>
+	</li>
+	<li class="sidebar__item">
+		<a
+			data-sveltekit-reload
+			href="/suasana-hati/"
+			class="flex gap-2 items-center p-2 rounded-md hover:bg-primary focus:bg-primary"
+		>
+			<HeartIcon />
+			{$t('navigation.mood')}
 		</a>
 	</li>
 	<li class="sidebar__item">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,7 +31,8 @@ export const CONSTANTS = {
 		THEME: 'theme',
 		LOG_PRAYER: 'log',
 		DOA_CATEGORY: 'doa_cat',
-		ADHKAR_LOG: 'adhkar_log'
+		ADHKAR_LOG: 'adhkar_log',
+		MOOD: 'mood'
 	},
 	BISMILLAH: '﷽'
 };
@@ -87,6 +88,9 @@ export const META_DESC_PENCATAT_IBADAH = `Mulai catat ibadahmu untuk refleksi di
 export const META_TITLE_ADHKAR = `Dzikir Pagi & Petang (al-Ma'thurat) | ${TITLE_CONSTANTS.TITLE_META}`;
 export const META_DESC_ADHKAR = `Checklist dzikir pagi dan petang lengkap dengan penghitung tiap dzikir, otomatis reset di pergantian waktu sesuai jadwal sholat. ${postfix(false)}`;
 
+export const META_TITLE_SUASANA_HATI = `Ayat Al-Qur'an Sesuai Suasana Hati | ${TITLE_CONSTANTS.TITLE_META}`;
+export const META_DESC_SUASANA_HATI = `Temukan ayat Al-Qur'an yang sesuai dengan suasana hatimu — cemas, bersyukur, sedih, takut, marah, dan lainnya. ${postfix(false)}`;
+
 export const META_TITLE_SURAH = (name: string) =>
 	`Qur'an Surat ${name} | ${TITLE_CONSTANTS.TITLE_META}`;
 export const META_DESC_SURAH = (name: string) => `Qur'an Surat ${name} ${postfix(true)}`;
@@ -127,7 +131,8 @@ export type PageVariant =
 	| 'MADANIYAH'
 	| 'JADWAL_SHOLAT'
 	| 'CATAT_IBADAH'
-	| 'ADHKAR';
+	| 'ADHKAR'
+	| 'SUASANA_HATI';
 // Using translation system instead of direct language comparison
 
 export const SEO_TEXT = {
@@ -157,6 +162,8 @@ export const SEO_TEXT = {
 		'Catat ibadahmu untuk refleksi diri. Pencatat ibadah online dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.',
 	ADHKAR:
 		"Dzikir pagi dan petang (al-Ma'thurat) lengkap dengan penghitung otomatis dan reset harian. Langsung dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.",
+	SUASANA_HATI:
+		"Temukan ayat Al-Qur'an yang sesuai suasana hatimu. Pilih suasana hati dan baca ayat-ayat yang relevan beserta terjemahannya. Langsung dari peramban, tanpa iklan, tanpa analitik, privasi aman dan gratis sepenuhnya.",
 	SURAH_DETAIL: '',
 	AYAT_DETAIL: ''
 };

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -43,7 +43,8 @@
 		"stories": "Stories",
 		"tulisan": "Articles",
 		"designSystem": "Design System",
-		"adhkar": "Morning & Evening Adhkar"
+		"adhkar": "Morning & Evening Adhkar",
+		"mood": "Mood"
 	},
 	"surah": {
 		"title": "Read Quran",
@@ -328,6 +329,23 @@
 			"interactive": "Interactive (button / link)",
 			"withoutDecorative": "Without decorative circles",
 			"indexBased": "Index-based selection — useful for lists"
+		}
+	},
+	"mood": {
+		"title": "💭 Mood",
+		"subtitle": "Find Quranic verses that speak to how you feel right now.",
+		"pickRandom": "Pick a Random Verse",
+		"readFullAyah": "Read Full Ayah",
+		"disclaimer": "These verse selections are hand-curated. They are not exhaustive and may grow over time.",
+		"moods": {
+			"cemas": "Anxious",
+			"bersyukur": "Grateful",
+			"sedih": "Grieving",
+			"takut": "Fearful",
+			"marah": "Angry",
+			"lemah_iman": "Wavering Faith",
+			"tobat": "Repentant",
+			"bahagia": "Joyful"
 		}
 	},
 	"tahlil": {

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -43,7 +43,8 @@
 		"stories": "Stories",
 		"tulisan": "Tulisan",
 		"designSystem": "Sistem Desain",
-		"adhkar": "Dzikir Pagi & Petang"
+		"adhkar": "Dzikir Pagi & Petang",
+		"mood": "Suasana Hati"
 	},
 	"surah": {
 		"title": "Baca Qur'an",
@@ -328,6 +329,23 @@
 			"interactive": "Interaktif (button / link)",
 			"withoutDecorative": "Tanpa dekorasi lingkaran",
 			"indexBased": "Pemilihan berbasis indeks — berguna untuk daftar"
+		}
+	},
+	"mood": {
+		"title": "💭 Suasana Hati",
+		"subtitle": "Temukan ayat Al-Qur'an yang sesuai dengan perasaanmu saat ini.",
+		"pickRandom": "Acak / Pilih Satu",
+		"readFullAyah": "Baca Ayat Selengkapnya",
+		"disclaimer": "Pilihan ayat ini dikurasi secara manual. Tidak bersifat eksklusif dan dapat terus berkembang.",
+		"moods": {
+			"cemas": "Cemas",
+			"bersyukur": "Bersyukur",
+			"sedih": "Sedih",
+			"takut": "Takut",
+			"marah": "Marah",
+			"lemah_iman": "Lemah Iman",
+			"tobat": "Tobat",
+			"bahagia": "Bahagia"
 		}
 	},
 	"tahlil": {

--- a/src/lib/utils/verseLoader.ts
+++ b/src/lib/utils/verseLoader.ts
@@ -1,0 +1,17 @@
+export interface LoadedVerse {
+	arabic: string;
+	translation: string;
+	surahLatin: string;
+}
+
+export async function loadVerse(surahId: number, verseId: number): Promise<LoadedVerse> {
+	const surahMod = await import(`../../data/surah-data/${surahId}.ts`);
+	const surahInfoMod = await import(`../../data/surah-info/${surahId}.ts`);
+	const surah = surahMod.default[String(surahId)];
+	const surahInfo = surahInfoMod.default.current;
+	return {
+		arabic: surah.text[String(verseId)],
+		translation: surah.translations.id.text[String(verseId)],
+		surahLatin: surahInfo.latin
+	};
+}

--- a/src/routes/suasana-hati/+page.svelte
+++ b/src/routes/suasana-hati/+page.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import MetaTag from '$lib/MetaTag.svelte';
+	import Breadcrumb from '$lib/Breadcrumb.svelte';
+	import SeoText from '$lib/SeoText.svelte';
+	import CardShadow from '$lib/CardShadow.svelte';
+	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
+	import {
+		META_TITLE_SUASANA_HATI,
+		META_DESC_SUASANA_HATI,
+		TITLE_CONSTANTS,
+		CONSTANTS
+	} from '$lib/constants';
+	import { t } from '$lib/translations/store';
+	import { languageStore, LANGUAGE_OPTIONS } from '$lib/checkLanguaguage';
+	import { MOODS, type MoodId, type MoodVerse } from '$data/mood-verses';
+	import { loadVerse } from '$lib/utils/verseLoader';
+
+	const isEnglish = $derived($languageStore === LANGUAGE_OPTIONS.ENGLISH.locale);
+
+	type LoadedVerse = {
+		verse: MoodVerse;
+		arabic: string;
+		translation: string;
+		surahLatin: string;
+	};
+
+	let activeMoodId: MoodId | null = $state(null);
+	let loadedVerses: LoadedVerse[] = $state([]);
+	let loading = $state(false);
+	let highlightedIndex: number | null = $state(null);
+
+	const activeMood = $derived(
+		activeMoodId ? (MOODS.find((m) => m.id === activeMoodId) ?? null) : null
+	);
+
+	async function selectMood(moodId: MoodId) {
+		if (activeMoodId === moodId) return;
+		activeMoodId = moodId;
+		highlightedIndex = null;
+		loading = true;
+		loadedVerses = [];
+
+		try {
+			localStorage.setItem(CONSTANTS.STORAGE_KEY.MOOD, moodId);
+		} catch {
+			// ignore storage errors
+		}
+
+		const mood = MOODS.find((m) => m.id === moodId);
+		if (!mood) {
+			loading = false;
+			return;
+		}
+
+		const results = await Promise.all(
+			mood.verses.map(async (verse) => {
+				const { arabic, translation, surahLatin } = await loadVerse(verse.s, verse.v);
+				return { verse, arabic, translation, surahLatin };
+			})
+		);
+
+		loadedVerses = results;
+		loading = false;
+	}
+
+	function pickRandom() {
+		if (loadedVerses.length === 0) return;
+		const idx = Math.floor(Math.random() * loadedVerses.length);
+		highlightedIndex = idx;
+		setTimeout(() => {
+			document
+				.getElementById(`verse-${idx}`)
+				?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		}, 50);
+	}
+
+	onMount(() => {
+		try {
+			const saved = localStorage.getItem(CONSTANTS.STORAGE_KEY.MOOD) as MoodId | null;
+			if (saved && MOODS.some((m) => m.id === saved)) {
+				selectMood(saved);
+			}
+		} catch {
+			// ignore storage errors
+		}
+	});
+</script>
+
+<svelte:head>
+	<MetaTag
+		title={META_TITLE_SUASANA_HATI}
+		desc={META_DESC_SUASANA_HATI}
+		url={`${TITLE_CONSTANTS.PATH}suasana-hati/`}
+	/>
+</svelte:head>
+
+<div class="flex gap-2 px-4 mb-4">
+	<h1 class="text-3xl font-bold">{$t('mood.title')}</h1>
+</div>
+
+<div class="px-4 mb-4">
+	<Breadcrumb items={[{ text: `🏠 ${$t('navigation.home')}`, href: '/' }]} />
+</div>
+
+<div class="px-4 mb-6">
+	<p class="text-sm text-foreground-secondary">{$t('mood.subtitle')}</p>
+</div>
+
+<div class="px-4 mb-6 flex flex-wrap gap-2">
+	{#each MOODS as mood}
+		<button
+			class="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border transition-colors {activeMoodId ===
+			mood.id
+				? 'bg-primary border-primary font-semibold'
+				: 'border-secondary hover:bg-primary'}"
+			onclick={() => selectMood(mood.id)}
+		>
+			<span>{mood.emoji}</span>
+			<span>{$t(mood.labelKey)}</span>
+		</button>
+	{/each}
+</div>
+
+{#if activeMood}
+	<div class="px-4 mb-4 flex justify-between items-center gap-2">
+		<p class="text-sm text-foreground-secondary">
+			{activeMood.emoji}
+			{isEnglish ? 'Verses for:' : 'Ayat untuk:'} <strong>{$t(activeMood.labelKey)}</strong>
+		</p>
+		<button
+			onclick={pickRandom}
+			class="flex items-center gap-1.5 px-3 py-2 rounded-md bg-primary text-sm font-medium hover:opacity-80 transition-opacity whitespace-nowrap"
+		>
+			🎲 {$t('mood.pickRandom')}
+		</button>
+	</div>
+
+	<div class="px-4 flex flex-col gap-4 pb-24">
+		{#if loading}
+			<CardShadow>
+				<p class="text-foreground-secondary text-sm">{$t('common.loading')}</p>
+			</CardShadow>
+		{:else}
+			{#each loadedVerses as item, idx}
+				<div id={`verse-${idx}`}>
+					<CardShadow>
+						<div
+							class="flex flex-col gap-3 {highlightedIndex === idx
+								? 'outline outline-2 outline-blue-500 rounded-md p-1'
+								: ''}"
+						>
+							<div class="flex justify-between items-center gap-2">
+								<span class="text-xs text-foreground-secondary font-medium">
+									{item.surahLatin} : {item.verse.v}
+								</span>
+							</div>
+							<p class="font-arabic text-2xl text-right leading-loose" dir="rtl">
+								{item.arabic}
+							</p>
+							<p class="text-sm text-foreground-secondary">
+								{item.translation}
+							</p>
+							<p class="text-xs italic text-foreground-secondary border-t border-secondary pt-2">
+								{isEnglish ? item.verse.reasonEn : item.verse.reasonId}
+							</p>
+							<a
+								href={`/surah/${item.verse.s}/#ayat-${item.verse.v}`}
+								class="flex bg-primary items-center justify-center gap-2 cursor-pointer p-2 rounded-md focus:ring-2 focus:ring-blue-500 text-sm"
+								data-sveltekit-reload
+							>
+								{$t('mood.readFullAyah')}
+								<ArrowRightIcon />
+							</a>
+						</div>
+					</CardShadow>
+				</div>
+			{/each}
+
+			<p class="text-xs text-foreground-secondary text-center mt-2 px-4">
+				{$t('mood.disclaimer')}
+			</p>
+		{/if}
+	</div>
+{/if}
+
+<SeoText variant="SUASANA_HATI" />


### PR DESCRIPTION
Implements the full mood-based Qur'an verse picker feature:

- New `src/data/mood-verses.ts`: 8 moods (cemas, bersyukur, sedih, takut,
  marah, lemah-iman, tobat, bahagia) each with 5 curated verses. Every verse
  carries { s, v, reasonId, reasonEn } — compact references resolved at
  render time, same pattern as AyahOfTheDay.

- New `src/lib/utils/verseLoader.ts`: shared helper that dynamically imports
  surah-data and surah-info for a given (surahId, verseId) pair, returning
  arabic text, Indonesian translation, and surah Latin name.

- New `src/routes/suasana-hati/+page.svelte`: mood chip row (emoji + label),
  per-mood verse cards (Arabic, translation, curated reason, deep link to
  /surah/{s}/#ayat-{v}), "Pick Random" button with scroll-to-highlight,
  last-selected mood persisted in localStorage.

- `src/lib/constants.ts`: STORAGE_KEY.MOOD, META_TITLE/DESC_SUASANA_HATI,
  'SUASANA_HATI' added to PageVariant and SEO_TEXT.

- `src/lib/DrawerMenus.svelte`: new sidebar entry with HeartIcon.

- `src/lib/translations/{id,en}.json`: mood.* and navigation.mood keys.

- `scripts/routes.js`: /suasana-hati added for prerender + sitemap.

Verse list for reviewer sanity-check:
  cemas:      13:28, 94:5, 94:6, 2:286, 65:3
  bersyukur:  14:7, 55:13, 1:2, 2:152, 31:12
  sedih:      94:5, 3:139, 39:53, 12:87, 2:286
  takut:      2:255, 9:51, 65:3, 3:173, 67:13
  marah:      3:134, 41:34, 7:199, 42:37, 25:63
  lemah-iman: 8:2, 57:28, 49:15, 2:2, 9:128
  tobat:      39:53, 2:222, 4:110, 9:104, 66:8
  bahagia:    13:28, 16:97, 55:60, 98:8, 3:185

Closes #414

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MGP1uRp2pEavhEQk6KB2M7