### PR TITLE
fix: resolve svelte-check and eslint warnings

### DIFF
--- a/src/lib/SurahList.svelte
+++ b/src/lib/SurahList.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import SearchInput from '$lib/SearchInput.svelte';
 	import SurahCard from '$lib/SurahCard.svelte';
 	import type { SurahInfo } from '../data/surah-info';
@@ -12,7 +10,6 @@
 	let { originSurahInfo }: Props = $props();
 
 	let searchText = $state('');
-	let filteredSurahInfo: SurahInfo = $state(originSurahInfo);
 	const noSpecialChars = (str: string) => str.replace(/[^a-zA-Z0-9 ]/g, '');
 
 	const handleSearchChange = (e: Event) => {
@@ -20,7 +17,7 @@
 		searchText = target?.value || '';
 	};
 
-	run(() => {
+	const filteredSurahInfo = $derived.by(() => {
 		if (searchText.length > 1) {
 			let result: SurahInfo = {};
 
@@ -37,10 +34,10 @@
 				}
 			}
 
-			filteredSurahInfo = result;
-		} else {
-			filteredSurahInfo = originSurahInfo;
+			return result;
 		}
+
+		return originSurahInfo;
 	});
 </script>
 

--- a/src/lib/ui/GradientCard.svelte
+++ b/src/lib/ui/GradientCard.svelte
@@ -118,10 +118,11 @@
 		`relative overflow-hidden bg-gradient-to-br ${gradientClass} ${PADDING_MAP[padding]} ${ROUNDED_MAP[rounded]} ${clazz}`
 	);
 
-	const interactiveClass =
+	const interactiveClass = $derived(
 		as === 'button' || as === 'a'
 			? 'cursor-pointer transition-transform hover:scale-[1.02] active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
-			: '';
+			: ''
+	);
 
 	const patternStyle = $derived(
 		pattern !== 'none'

--- a/src/lib/ui/StepNav.svelte
+++ b/src/lib/ui/StepNav.svelte
@@ -38,12 +38,6 @@
 
 	const isFirst = $derived(current === 0);
 	const isLast = $derived(current === total - 1);
-
-	const SIZE_MAP: Record<Size, string> = {
-		sm: 'text-sm px-3 py-1.5 gap-1.5',
-		md: 'text-base px-4 py-2 gap-2',
-		lg: 'text-base px-4 py-2.5 gap-2'
-	};
 </script>
 
 <div class="flex justify-between items-center gap-3 {clazz}">

--- a/src/lib/views/SurahPage.svelte
+++ b/src/lib/views/SurahPage.svelte
@@ -18,9 +18,9 @@
 
 	let { data }: Props = $props();
 
-	let surahid = data?.surahid;
-	let surahData = data?.surahData;
-	let surahInfo = data?.surahInfo as SurahInfoPage;
+	let surahid = $derived(data?.surahid);
+	let surahData = $derived(data?.surahData);
+	let surahInfo = $derived(data?.surahInfo as SurahInfoPage);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let timeout: any = null;
 	onMount(() => {

--- a/src/lib/views/VersePage.svelte
+++ b/src/lib/views/VersePage.svelte
@@ -18,10 +18,10 @@
 
 	let { data }: Props = $props();
 
-	let surahid = data?.surahid;
-	let verseid = data?.verseid;
-	let verseData = data?.verseData;
-	let surahInfo = data?.surahInfo as SurahInfoPage;
+	let surahid = $derived(data?.surahid);
+	let verseid = $derived(data?.verseid);
+	let verseData = $derived(data?.verseData);
+	let surahInfo = $derived(data?.surahInfo as SurahInfoPage);
 </script>
 
 <svelte:head>

--- a/src/routes/iqra/1/+page.svelte
+++ b/src/routes/iqra/1/+page.svelte
@@ -9,8 +9,6 @@
 	import { IQRA_1_HALAMAN, IQRA_LEVELS } from '$data/iqra';
 	import SpeakerWaveIcon from '$lib/icons/SpeakerWaveIcon.svelte';
 	import StepNav from '$lib/ui/StepNav.svelte';
-	import ResetIcon from '$lib/icons/ResetIcon.svelte';
-	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import SeoText from '$lib/SeoText.svelte';
 	import { settingFontStyle } from '$store';
 	import {
@@ -54,10 +52,6 @@
 		}
 	}
 
-	function jumpTo(index: number) {
-		currentIndex = index;
-	}
-
 	function restart() {
 		resetJilidProgress(JILID);
 		seen = new Array(halaman.length).fill(false);
@@ -82,7 +76,6 @@
 	}
 
 	const currentHalaman = $derived(halaman[currentIndex]);
-	const seenCount = $derived(seen.filter(Boolean).length);
 	const nextLevel = IQRA_LEVELS.find((l) => l.jilid === JILID + 1);
 
 	const ttsSupported = $derived(typeof speechSynthesis !== 'undefined');


### PR DESCRIPTION
## Summary
- Fix `state_referenced_locally` svelte-check warnings by converting prop-derived values (`data`, `originSurahInfo`, `as`) to `$derived`, so navigating between surah/verse pages actually updates the displayed content instead of only using the initially-mounted values.
- Modernize `SurahList.svelte`'s search filtering from legacy `run()` reactive statement to `$derived.by`.
- Remove unused imports/vars flagged by eslint (`SIZE_MAP`, `ResetIcon`, `ArrowRightIcon`, `jumpTo`, `seenCount`).

`pnpm run check` and `pnpm run lint` are both clean now (0 errors, 0 warnings).

## Test plan
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run lint` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)