### PR TITLE
feat(iqra): replace auto-resume progress with explicit bookmarks

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -456,6 +456,8 @@
 		"openLabel": "Open",
 		"bookmarkAdd": "Bookmark this page",
 		"bookmarkRemove": "Remove bookmark",
+		"bookmarkAdded": "Page bookmarked!",
+		"bookmarkRemoved": "Bookmark removed",
 		"continueFromBookmark": "Continue from Bookmark",
 		"bookmarkedPage": "Page {{page}}"
 	}

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -452,6 +452,11 @@
 		"overallProgress": "{{completed}} of {{total}} levels complete",
 		"nextLevel": "Continue to Jilid {{number}}",
 		"nextLevelComingSoon": "Jilid {{number}} not yet available",
-		"restartLabel": "Start Over"
+		"restartLabel": "Start Over",
+		"openLabel": "Open",
+		"bookmarkAdd": "Bookmark this page",
+		"bookmarkRemove": "Remove bookmark",
+		"continueFromBookmark": "Continue from Bookmark",
+		"bookmarkedPage": "Page {{page}}"
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -452,6 +452,11 @@
 		"overallProgress": "{{completed}} dari {{total}} jilid selesai",
 		"nextLevel": "Lanjut ke Jilid {{number}}",
 		"nextLevelComingSoon": "Jilid {{number}} belum tersedia",
-		"restartLabel": "Mulai dari Awal"
+		"restartLabel": "Mulai dari Awal",
+		"openLabel": "Buka",
+		"bookmarkAdd": "Tandai halaman ini",
+		"bookmarkRemove": "Hapus tanda halaman ini",
+		"continueFromBookmark": "Lanjutkan dari Bookmark",
+		"bookmarkedPage": "Halaman {{page}}"
 	}
 }

--- a/src/lib/translations/id.json
+++ b/src/lib/translations/id.json
@@ -456,6 +456,8 @@
 		"openLabel": "Buka",
 		"bookmarkAdd": "Tandai halaman ini",
 		"bookmarkRemove": "Hapus tanda halaman ini",
+		"bookmarkAdded": "Halaman berhasil ditandai!",
+		"bookmarkRemoved": "Tanda halaman dihapus",
 		"continueFromBookmark": "Lanjutkan dari Bookmark",
 		"bookmarkedPage": "Halaman {{page}}"
 	}

--- a/src/lib/ui/StepNav.svelte
+++ b/src/lib/ui/StepNav.svelte
@@ -3,6 +3,7 @@
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
 	import ChevronLeftIcon from '$lib/icons/ChevronLeftIcon.svelte';
 	import ChevronRightIcon from '$lib/icons/ChevronRightIcon.svelte';
+	import ChevronDownIcon from '$lib/icons/ChevronDownIcon.svelte';
 	import Button from '$lib/ui/Button.svelte';
 
 	type Size = 'sm' | 'md' | 'lg';
@@ -13,6 +14,7 @@
 		total: number;
 		onPrev: () => void;
 		onNext: () => void;
+		onJumpTo?: (index: number) => void;
 		prevLabel?: string;
 		nextLabel?: string;
 		finishLabel?: string;
@@ -27,6 +29,7 @@
 		total,
 		onPrev,
 		onNext,
+		onJumpTo,
 		prevLabel = 'Previous',
 		nextLabel = 'Next',
 		finishLabel = 'Finish',
@@ -36,34 +39,81 @@
 		class: clazz = ''
 	}: Props = $props();
 
+	function handleJump(e: Event) {
+		const value = Number((e.currentTarget as HTMLSelectElement).value);
+		onJumpTo?.(value - 1);
+	}
+
 	const isFirst = $derived(current === 0);
 	const isLast = $derived(current === total - 1);
+
+	const maxLabelChars = $derived(Math.max(prevLabel.length, nextLabel.length, finishLabel.length));
+	const buttonMinWidth = $derived(`${maxLabelChars + 6}ch`);
 </script>
 
 <div class="flex justify-between items-center gap-3 {clazz}">
-	<Button onClick={onPrev} variant="outline" color="secondary" {size} disabled={isFirst} class="">
-		{#if iconVariant === 'chevron'}
-			<ChevronLeftIcon size="sm" class="w-4 h-4 shrink-0" />
-		{:else}
-			<ArrowLeftIcon size="sm" class="w-4 h-4 shrink-0" />
-		{/if}
-		{prevLabel}
-	</Button>
+	<span class="inline-block" style="min-width: {buttonMinWidth}">
+		<Button
+			onClick={onPrev}
+			variant="outline"
+			color="secondary"
+			{size}
+			disabled={isFirst}
+			class="w-full justify-center"
+		>
+			{#if iconVariant === 'chevron'}
+				<ChevronLeftIcon size="sm" class="w-4 h-4 shrink-0" />
+			{:else}
+				<ArrowLeftIcon size="sm" class="w-4 h-4 shrink-0" />
+			{/if}
+			{prevLabel}
+		</Button>
+	</span>
 
 	{#if showCounter}
-		<div
-			class="flex flex-1 text-center items-center justify-center text-sm tabular-nums text-foreground-secondary whitespace-nowrap shrink-0"
-		>
-			{current + 1} / {total}
-		</div>
+		{#if onJumpTo}
+			<div class="flex flex-1 items-center justify-center gap-1 text-sm shrink-0">
+				<div class="relative">
+					<select
+						value={current + 1}
+						onchange={handleJump}
+						aria-label="Jump to page"
+						class="appearance-none rounded-md border border-foreground/20 bg-secondary text-foreground text-sm tabular-nums pl-1.5 pr-6 py-1 w-[4.5rem] min-w-[4.5rem]"
+					>
+						{#each Array.from({ length: total }, (_, i) => i + 1) as pageNumber}
+							<option value={pageNumber}>{pageNumber}</option>
+						{/each}
+					</select>
+					<ChevronDownIcon
+						size="xs"
+						class="w-3.5 h-3.5 absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-foreground-secondary"
+					/>
+				</div>
+				<span class="text-foreground-secondary whitespace-nowrap">/ {total}</span>
+			</div>
+		{:else}
+			<div
+				class="flex flex-1 text-center items-center justify-center text-sm tabular-nums text-foreground-secondary whitespace-nowrap shrink-0"
+			>
+				{current + 1} / {total}
+			</div>
+		{/if}
 	{/if}
 
-	<Button onClick={onNext} variant="outline" color="secondary" {size} class="">
-		{isLast ? finishLabel : nextLabel}
-		{#if iconVariant === 'chevron'}
-			<ChevronRightIcon size="sm" class="w-4 h-4 shrink-0" />
-		{:else}
-			<ArrowRightIcon size="sm" class="w-4 h-4 shrink-0" />
-		{/if}
-	</Button>
+	<span class="inline-block" style="min-width: {buttonMinWidth}">
+		<Button
+			onClick={onNext}
+			variant="outline"
+			color="secondary"
+			{size}
+			class="w-full justify-center"
+		>
+			{isLast ? finishLabel : nextLabel}
+			{#if iconVariant === 'chevron'}
+				<ChevronRightIcon size="sm" class="w-4 h-4 shrink-0" />
+			{:else}
+				<ArrowRightIcon size="sm" class="w-4 h-4 shrink-0" />
+			{/if}
+		</Button>
+	</span>
 </div>

--- a/src/lib/utils/iqraProgress.ts
+++ b/src/lib/utils/iqraProgress.ts
@@ -2,9 +2,15 @@ import { CONSTANTS } from '$lib/constants';
 
 const KEY = CONSTANTS.STORAGE_KEY.IQRA_PROGRESS;
 
+export interface IqraBookmark {
+	pageIndex: number;
+	updatedAt: string;
+}
+
 export interface IqraProgress {
 	levels: Record<number, boolean[]>;
 	completedAt: Record<number, string>;
+	bookmarks: Record<number, IqraBookmark>;
 }
 
 export const LESSON_COUNT: Record<number, number> = {
@@ -17,7 +23,7 @@ export const LESSON_COUNT: Record<number, number> = {
 };
 
 function empty(): IqraProgress {
-	return { levels: {}, completedAt: {} };
+	return { levels: {}, completedAt: {}, bookmarks: {} };
 }
 
 export function loadProgress(): IqraProgress {
@@ -25,7 +31,12 @@ export function loadProgress(): IqraProgress {
 	try {
 		const raw = localStorage.getItem(KEY);
 		if (!raw) return empty();
-		return JSON.parse(raw) as IqraProgress;
+		const parsed = JSON.parse(raw) as Partial<IqraProgress>;
+		return {
+			levels: parsed.levels ?? {},
+			completedAt: parsed.completedAt ?? {},
+			bookmarks: parsed.bookmarks ?? {}
+		};
 	} catch {
 		return empty();
 	}
@@ -66,10 +77,48 @@ export function resetJilidProgress(jilid: number): void {
 	const p = loadProgress();
 	delete p.levels[jilid];
 	delete p.completedAt[jilid];
+	delete p.bookmarks[jilid];
 	save(p);
 }
 
 export function resetProgress(): void {
 	if (typeof localStorage === 'undefined') return;
 	localStorage.removeItem(KEY);
+}
+
+export function setBookmark(jilid: number, pageIndex: number): IqraProgress {
+	const p = loadProgress();
+	p.bookmarks[jilid] = { pageIndex, updatedAt: new Date().toISOString() };
+	save(p);
+	return p;
+}
+
+export function clearBookmark(jilid: number): IqraProgress {
+	const p = loadProgress();
+	delete p.bookmarks[jilid];
+	save(p);
+	return p;
+}
+
+export function getBookmark(jilid: number): IqraBookmark | undefined {
+	return loadProgress().bookmarks[jilid];
+}
+
+export function getLatestBookmark(): {
+	jilid: number;
+	pageIndex: number;
+	updatedAt: string;
+} | null {
+	const p = loadProgress();
+	let latest: { jilid: number; pageIndex: number; updatedAt: string } | null = null;
+	for (const [jilidStr, bookmark] of Object.entries(p.bookmarks)) {
+		if (!latest || bookmark.updatedAt > latest.updatedAt) {
+			latest = {
+				jilid: Number(jilidStr),
+				pageIndex: bookmark.pageIndex,
+				updatedAt: bookmark.updatedAt
+			};
+		}
+	}
+	return latest;
 }

--- a/src/routes/iqra/+page.svelte
+++ b/src/routes/iqra/+page.svelte
@@ -7,10 +7,16 @@
 	import { TITLE_CONSTANTS } from '$lib/constants';
 	import { t } from '$lib/translations/store';
 	import { IQRA_LEVELS } from '$data/iqra';
-	import { getLevelStats, isLevelComplete, resetProgress } from '$lib/utils/iqraProgress';
+	import {
+		getLevelStats,
+		isLevelComplete,
+		resetProgress,
+		getLatestBookmark
+	} from '$lib/utils/iqraProgress';
 	import ProgressBar from '$lib/ui/ProgressBar.svelte';
 	import ResetIcon from '$lib/icons/ResetIcon.svelte';
 	import ArrowRightIcon from '$lib/icons/ArrowRightIcon.svelte';
+	import BookmarkSolidIcon from '$lib/icons/BookmarkSolidIcon.svelte';
 	import SeoText from '$lib/SeoText.svelte';
 
 	type LevelStats = { completed: number; total: number };
@@ -18,6 +24,7 @@
 	let stats = $state<Record<number, LevelStats>>({});
 	let completedLevels = $state<Record<number, boolean>>({});
 	let showResetConfirm = $state(false);
+	let latestBookmark = $state<{ jilid: number; pageIndex: number } | null>(null);
 
 	onMount(() => {
 		refreshStats();
@@ -32,6 +39,7 @@
 		}
 		stats = s;
 		completedLevels = c;
+		latestBookmark = getLatestBookmark();
 	}
 
 	function handleReset() {
@@ -116,6 +124,27 @@
 	</div>
 </div>
 
+{#if latestBookmark}
+	<div class="px-4 mb-4">
+		<a
+			href="/iqra/{latestBookmark.jilid}/?page={latestBookmark.pageIndex + 1}"
+			class="flex items-center justify-between gap-2 rounded-lg overflow-hidden shadow p-4 bg-control-accent text-control-surface hover:opacity-90 transition"
+		>
+			<div class="flex items-center gap-2.5">
+				<BookmarkSolidIcon size="md" class="w-5 h-5 shrink-0" />
+				<div>
+					<div class="font-bold text-base">{$t('iqra.continueFromBookmark')}</div>
+					<div class="text-sm opacity-90">
+						{$t('iqra.levelLabel', { number: String(latestBookmark.jilid) })} ·
+						{$t('iqra.bookmarkedPage', { page: String(latestBookmark.pageIndex + 1) })}
+					</div>
+				</div>
+			</div>
+			<ArrowRightIcon size="sm" class="w-4 h-4 shrink-0" />
+		</a>
+	</div>
+{/if}
+
 <div class="px-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
 	{#each IQRA_LEVELS as level (level.jilid)}
 		{@const levelStats = stats[level.jilid] ?? { completed: 0, total: 0 }}
@@ -150,13 +179,7 @@
 				/>
 
 				<div class="mt-1 text-sm font-medium text-foreground-secondary flex items-center gap-1">
-					{#if isDone}
-						{$t('iqra.reviewLabel')}
-					{:else if levelStats.completed > 0}
-						{$t('iqra.continueLabel')}
-					{:else}
-						{$t('iqra.startLabel')}
-					{/if}
+					{$t('iqra.openLabel')}
 					<ArrowRightIcon size="sm" class="w-3.5 h-3.5 shrink-0" />
 				</div>
 			</a>

--- a/src/routes/iqra/1/+page.svelte
+++ b/src/routes/iqra/1/+page.svelte
@@ -10,6 +10,7 @@
 	import BookmarkSolidIcon from '$lib/icons/BookmarkSolidIcon.svelte';
 	import { TITLE_CONSTANTS } from '$lib/constants';
 	import { t } from '$lib/translations/store';
+	import { toast } from '$store/toast';
 	import { IQRA_1_HALAMAN, IQRA_LEVELS } from '$data/iqra';
 	import SpeakerWaveIcon from '$lib/icons/SpeakerWaveIcon.svelte';
 	import StepNav from '$lib/ui/StepNav.svelte';
@@ -93,9 +94,11 @@
 		if (bookmarkedIndex === currentIndex) {
 			clearBookmark(JILID);
 			bookmarkedIndex = null;
+			toast.show({ message: $t('iqra.bookmarkRemoved'), type: 'info' });
 		} else {
 			setBookmark(JILID, currentIndex);
 			bookmarkedIndex = currentIndex;
+			toast.show({ message: $t('iqra.bookmarkAdded'), type: 'success' });
 		}
 	}
 

--- a/src/routes/iqra/1/+page.svelte
+++ b/src/routes/iqra/1/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { fly } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import Breadcrumb from '$lib/Breadcrumb.svelte';
 	import MetaTag from '$lib/MetaTag.svelte';
 	import BookOpenIcon from '$lib/icons/BookOpenIcon.svelte';
 	import CheckCircleSolidIcon from '$lib/icons/CheckCircleSolidIcon.svelte';
+	import BookmarkIcon from '$lib/icons/BookmarkIcon.svelte';
+	import BookmarkSolidIcon from '$lib/icons/BookmarkSolidIcon.svelte';
 	import { TITLE_CONSTANTS } from '$lib/constants';
 	import { t } from '$lib/translations/store';
 	import { IQRA_1_HALAMAN, IQRA_LEVELS } from '$data/iqra';
@@ -15,7 +19,10 @@
 		loadProgress,
 		markLessonDone,
 		isLevelComplete,
-		resetJilidProgress
+		resetJilidProgress,
+		getBookmark,
+		setBookmark,
+		clearBookmark
 	} from '$lib/utils/iqraProgress';
 
 	const JILID = 1;
@@ -24,23 +31,43 @@
 	let currentIndex = $state(0);
 	let isComplete = $state(false);
 	let seen = $state<boolean[]>(new Array(halaman.length).fill(false));
+	let slideDir = $state(1);
+	let bookmarkedIndex = $state<number | null>(null);
+
+	function clampIndex(i: number) {
+		return Math.min(Math.max(i, 0), halaman.length - 1);
+	}
+
+	function updatePageQueryParam(index: number) {
+		if (typeof window === 'undefined') return;
+		const url = new URL(window.location.href);
+		if (index > 0) {
+			url.searchParams.set('page', String(index + 1));
+		} else {
+			url.searchParams.delete('page');
+		}
+		window.history.replaceState({}, '', url.toString());
+	}
 
 	onMount(() => {
 		const progress = loadProgress();
 		const saved = progress.levels[JILID] ?? [];
 		seen = halaman.map((_, i) => saved[i] ?? false);
 		isComplete = isLevelComplete(JILID);
-		if (!isComplete) {
-			const firstUnseen = seen.findIndex((s) => !s);
-			currentIndex = firstUnseen >= 0 ? firstUnseen : 0;
-		}
+		bookmarkedIndex = getBookmark(JILID)?.pageIndex ?? null;
+
+		const params = new URLSearchParams(window.location.search);
+		const pageParam = params.get('page');
+		currentIndex = pageParam !== null ? clampIndex(Number(pageParam) - 1) : 0;
 	});
 
 	function goNext() {
 		seen[currentIndex] = true;
 		markLessonDone(JILID, currentIndex);
 		if (currentIndex < halaman.length - 1) {
+			slideDir = 1;
 			currentIndex++;
+			updatePageQueryParam(currentIndex);
 		} else {
 			isComplete = true;
 		}
@@ -48,7 +75,27 @@
 
 	function goPrev() {
 		if (currentIndex > 0) {
+			slideDir = -1;
 			currentIndex--;
+			updatePageQueryParam(currentIndex);
+		}
+	}
+
+	function jumpTo(index: number) {
+		const target = clampIndex(index);
+		if (target === currentIndex) return;
+		slideDir = target > currentIndex ? 1 : -1;
+		currentIndex = target;
+		updatePageQueryParam(currentIndex);
+	}
+
+	function toggleBookmark() {
+		if (bookmarkedIndex === currentIndex) {
+			clearBookmark(JILID);
+			bookmarkedIndex = null;
+		} else {
+			setBookmark(JILID, currentIndex);
+			bookmarkedIndex = currentIndex;
 		}
 	}
 
@@ -57,6 +104,8 @@
 		seen = new Array(halaman.length).fill(false);
 		currentIndex = 0;
 		isComplete = false;
+		bookmarkedIndex = null;
+		updatePageQueryParam(0);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -159,85 +208,106 @@
 		</div>
 	</div>
 {:else}
-	<StepNav
-		current={currentIndex}
-		total={halaman.length}
-		onPrev={goPrev}
-		onNext={goNext}
-		prevLabel={$t('common.previous')}
-		nextLabel={$t('common.next')}
-		finishLabel={$t('iqra.finish')}
-		showCounter
-		class="px-4 mb-4"
-	/>
-
-	<div class="px-4 mb-4">
-		<div class="rounded-2xl shadow-lg bg-secondary overflow-hidden">
-			{#if currentHalaman.label}
-				<div class="px-5 pt-4 text-center">
-					<span
-						class="inline-block rounded-full bg-control-accent/10 text-xs font-semibold px-3 py-1"
-					>
-						{currentHalaman.label}
-					</span>
-				</div>
+	<div class="px-4 mb-4 flex items-center gap-3">
+		<div class="flex-1">
+			<StepNav
+				current={currentIndex}
+				total={halaman.length}
+				onPrev={goPrev}
+				onNext={goNext}
+				onJumpTo={jumpTo}
+				prevLabel={$t('common.previous')}
+				nextLabel={$t('common.next')}
+				finishLabel={$t('iqra.finish')}
+				showCounter
+			/>
+		</div>
+		<button
+			onclick={toggleBookmark}
+			title={bookmarkedIndex === currentIndex ? $t('iqra.bookmarkRemove') : $t('iqra.bookmarkAdd')}
+			class="flex items-center justify-center rounded-md border border-foreground/20 bg-secondary w-10 h-10 shrink-0 hover:opacity-80 transition"
+		>
+			{#if bookmarkedIndex === currentIndex}
+				<BookmarkSolidIcon size="sm" class="w-5 h-5 text-control-accent" />
+			{:else}
+				<BookmarkIcon size="sm" class="w-5 h-5 text-foreground-secondary" />
 			{/if}
+		</button>
+	</div>
 
-			<!-- New letters -->
-			{#if currentHalaman.newLetters.length > 0}
-				<div class="px-5 pt-5 pb-4 border-b border-foreground/10">
-					<div class="flex gap-3 justify-center" dir="rtl">
-						{#each currentHalaman.newLetters as letter}
-							<button
-								onclick={() => speakGroup([letter.withFathah])}
-								class="flex flex-col items-center gap-2 rounded-2xl bg-primary shadow-sm px-6 py-4 flex-1 max-w-[150px] hover:shadow-md active:scale-95 transition-all"
-							>
-								<span class="{arabicFontClass} text-5xl leading-[1.5] py-2"
-									>{letter.withFathah}</span
-								>
-								<span class="text-sm font-semibold leading-none">{letter.name}</span>
-								<span class="text-xs text-foreground-secondary font-mono">/{letter.bunyi}/</span>
-								{#if ttsSupported}
-									<SpeakerWaveIcon
-										size="xs"
-										class="w-3.5 h-3.5 text-foreground-secondary opacity-60 mt-0.5"
-									/>
-								{/if}
-							</button>
-						{/each}
+	<div class="px-4 mb-4 grid overflow-x-hidden">
+		{#key currentIndex}
+			<div
+				class="rounded-2xl shadow-lg bg-secondary overflow-hidden [grid-area:1/1]"
+				in:fly={{ x: slideDir * 380, duration: 380, easing: cubicOut }}
+				out:fly={{ x: -slideDir * 380, duration: 280 }}
+			>
+				{#if currentHalaman.label}
+					<div class="px-5 pt-4 text-center">
+						<span
+							class="inline-block rounded-full bg-control-accent/10 text-xs font-semibold px-3 py-1"
+						>
+							{currentHalaman.label}
+						</span>
 					</div>
-				</div>
-			{/if}
+				{/if}
 
-			<!-- Reading rows -->
-			<div class="px-4 py-4">
-				<div class="flex flex-col gap-2" dir="rtl">
-					{#each currentHalaman.rows as row, rowIndex}
-						{@const isLastRow = rowIndex === currentHalaman.rows.length - 1}
-						{@const textSizeClass =
-							row.length > 5 ? 'text-xl' : row.length > 3 ? 'text-2xl' : 'text-3xl'}
-						<div class="flex flex-wrap gap-2 justify-center" dir="rtl">
-							{#each row as group}
+				<!-- New letters -->
+				{#if currentHalaman.newLetters.length > 0}
+					<div class="px-5 pt-5 pb-4 border-b border-foreground/10">
+						<div class="flex gap-3 justify-center" dir="rtl">
+							{#each currentHalaman.newLetters as letter}
 								<button
-									onclick={() => speakGroup(group)}
-									class="flex items-center justify-evenly gap-2 rounded-xl min-h-[4.25rem] px-3 flex-1 basis-20 active:scale-95 transition-all
-										{isLastRow ? 'bg-control-accent shadow-sm' : 'bg-primary shadow-sm hover:shadow-md'}"
+									onclick={() => speakGroup([letter.withFathah])}
+									class="flex flex-col items-center gap-2 rounded-2xl bg-primary shadow-sm px-6 py-4 flex-1 max-w-[150px] hover:shadow-md active:scale-95 transition-all"
 								>
-									{#each group as letter}
-										<span
-											class="{arabicFontClass} {textSizeClass} py-2 pointer-events-none whitespace-nowrap
-											{isLastRow ? 'text-control-surface' : 'text-foreground'}"
-										>
-											{letter}
-										</span>
-									{/each}
+									<span class="{arabicFontClass} text-5xl leading-[1.5] py-2"
+										>{letter.withFathah}</span
+									>
+									<span class="text-sm font-semibold leading-none">{letter.name}</span>
+									<span class="text-xs text-foreground-secondary font-mono">/{letter.bunyi}/</span>
+									{#if ttsSupported}
+										<SpeakerWaveIcon
+											size="xs"
+											class="w-3.5 h-3.5 text-foreground-secondary opacity-60 mt-0.5"
+										/>
+									{/if}
 								</button>
 							{/each}
 						</div>
-					{/each}
+					</div>
+				{/if}
+
+				<!-- Reading rows -->
+				<div class="px-4 py-4">
+					<div class="flex flex-col gap-2" dir="rtl">
+						{#each currentHalaman.rows as row, rowIndex}
+							{@const isLastRow = rowIndex === currentHalaman.rows.length - 1}
+							{@const textSizeClass =
+								row.length > 5 ? 'text-xl' : row.length > 3 ? 'text-2xl' : 'text-3xl'}
+							<div class="flex flex-wrap gap-2 justify-center" dir="rtl">
+								{#each row as group}
+									<button
+										onclick={() => speakGroup(group)}
+										class="flex items-center justify-evenly gap-2 rounded-xl min-h-[4.25rem] px-3 flex-1 basis-20 active:scale-95 transition-all
+											{isLastRow ? 'bg-control-accent shadow-sm' : 'bg-primary shadow-sm hover:shadow-md'}"
+									>
+										{#each group as letter}
+											<span
+												class="{arabicFontClass} {textSizeClass} py-2 pointer-events-none whitespace-nowrap
+												{isLastRow ? 'text-control-surface' : 'text-foreground'}"
+											>
+												{letter}
+											</span>
+										{/each}
+									</button>
+								{/each}
+							</div>
+						{/each}
+					</div>
 				</div>
 			</div>
-		</div>
+		{/key}
 	</div>
 
 	<StepNav
@@ -245,6 +315,7 @@
 		total={halaman.length}
 		onPrev={goPrev}
 		onNext={goNext}
+		onJumpTo={jumpTo}
 		prevLabel={$t('common.previous')}
 		nextLabel={$t('common.next')}
 		finishLabel={$t('iqra.finish')}


### PR DESCRIPTION
## Description

Replaces the automatic "resume from last opened page" behavior on the Iqra pages with an explicit bookmark feature, plus a few navigation UX improvements:

- Bookmark toggle button on each Iqra page (per jilid, stores page index + timestamp in localStorage)
- Iqra landing page shows a "Continue from Bookmark" shortcut linking to the most recently bookmarked page across jilid
- Level cards on the landing page always show "Buka" and always open page 1 (no more Mulai/Lanjutkan/Ulangi based on progress)
- Human-readable `?page=` query param (1-indexed) kept in sync via `history.replaceState` on next/prev/jump
- Jump-to-page `<select>` added to `StepNav`, with fixed widths on the select and Prev/Next/Finish buttons to avoid layout shift
- Sliding carousel transition between pages (grid-overlap technique to avoid a height-jump during the crossfade)
- Success/info toast when bookmarking/removing a bookmark

## Current Tasks

- [x] Bookmark storage + API (`iqraProgress.ts`)
- [x] Bookmark toggle UI + jump-to-page select (`iqra/1`, `StepNav`)
- [x] Landing page bookmark shortcut + "Buka" labels
- [x] Sliding transition without layout shift
- [x] Toast feedback on bookmark toggle
- [x] `svelte-check` / `eslint` clean, manually verified in browser